### PR TITLE
Finish bytes

### DIFF
--- a/bench/GeneralPerformance.hs
+++ b/bench/GeneralPerformance.hs
@@ -43,7 +43,7 @@ runTextToFile build = do
 runRopeToFile :: Rope -> IO ()
 runRopeToFile text = do 
     withFile "/tmp/garbage-rope.txt" WriteMode $ \handle -> do
-        hOutput handle text
+        hWrite handle text
 
 ----
 

--- a/lib/Core/Encoding/Json.hs
+++ b/lib/Core/Encoding/Json.hs
@@ -90,8 +90,6 @@ will get you:
     ) where
 
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as S
-import qualified Data.ByteString.Lazy as L
 import Data.Coerce
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
@@ -113,7 +111,7 @@ import qualified Data.Text as T
 import qualified Data.Vector as V
 import GHC.Generics
 
-import Core.Text.Bytes (Bytes(StrictBytes))
+import Core.Text.Bytes (Bytes, intoBytes, fromBytes)
 import Core.Text.Rope (Rope, Textual, intoRope, fromRope)
 import Core.Text.Utilities (Render(..))
 
@@ -124,16 +122,16 @@ I know we're not /supposed/ to rely on types to document functions, but
 really, this one does what it says on the tin.
 -}
 encodeToUTF8 :: JsonValue -> Bytes
-encodeToUTF8 = StrictBytes . S.concat . L.toChunks . Aeson.encode . intoAeson
+encodeToUTF8 = intoBytes . Aeson.encode . intoAeson
 
 {-|
 Given an array of bytes, attempt to decode it as a JSON value.
 -}
 decodeFromUTF8 :: Bytes -> Maybe JsonValue
-decodeFromUTF8 (StrictBytes b') =
+decodeFromUTF8 b =
   let
     x :: Maybe Aeson.Value
-    x = Aeson.decodeStrict' b'
+    x = Aeson.decodeStrict' (fromBytes b)
   in
     fmap fromAeson x
 

--- a/lib/Core/Program/Context.hs
+++ b/lib/Core/Program/Context.hs
@@ -20,6 +20,7 @@ module Core.Program.Context
       , getConsoleWidth
     ) where
 
+import Prelude hiding (log)
 import Chrono.TimeStamp (TimeStamp, getCurrentTimeNanoseconds)
 import Control.Concurrent.MVar (MVar, newMVar, newEmptyMVar)
 import Control.Concurrent.STM.TQueue (TQueue, newTQueueIO)

--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -232,7 +232,7 @@ processStandardOutput out = do
     forever $ do
         text <- atomically (readTQueue out)
 
-        hOutput stdout text
+        hWrite stdout text
         B.hPut stdout (C.singleton '\n')
 
 processDebugMessages :: TQueue Message -> IO ()

--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -85,8 +85,7 @@ import Prelude hiding (log)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (Async, async, link, cancel
     , ExceptionInLinkedThread(..), AsyncCancelled)
-import Control.Concurrent.MVar (MVar, newMVar, readMVar
-    , putMVar, modifyMVar_)
+import Control.Concurrent.MVar (readMVar, putMVar, modifyMVar_)
 import Control.Concurrent.STM (atomically, check)
 import Control.Concurrent.STM.TQueue (TQueue, readTQueue
     , writeTQueue, isEmptyTQueue)

--- a/lib/Core/Program/Logging.hs
+++ b/lib/Core/Program/Logging.hs
@@ -35,7 +35,7 @@ class Monad m => MonadLog a m where
 -}
 
 putMessage :: Context τ -> Message -> IO ()
-putMessage context message@(Message now nature text potentialValue) = do
+putMessage context message@(Message now _ text potentialValue) = do
     let start = startTimeFrom context
     let output = outputChannelFrom context
     let logger = loggerChannelFrom context

--- a/lib/Core/Program/Signal.hs
+++ b/lib/Core/Program/Signal.hs
@@ -6,7 +6,7 @@ module Core.Program.Signal
 )
 where
 
-import Control.Concurrent.MVar (MVar, putMVar, readMVar, modifyMVar_)
+import Control.Concurrent.MVar (MVar, putMVar, modifyMVar_)
 import Foreign.C.Types (CInt)
 import System.Exit (ExitCode(..))
 import System.IO (hPutStrLn, hFlush, stdout)

--- a/lib/Core/Text/Bytes.hs
+++ b/lib/Core/Text/Bytes.hs
@@ -27,7 +27,7 @@ binary data to make it easier to interoperate with libraries supplying
 or consuming bytes.
 -}
 module Core.Text.Bytes
-    ( Bytes(..)
+    ( Bytes
     , Binary(fromBytes, intoBytes)
     , chunk
     ) where
@@ -35,7 +35,7 @@ module Core.Text.Bytes
 import Data.Bits (Bits (..))
 import Data.Char (intToDigit)
 import qualified Data.ByteString as B (ByteString, foldl', splitAt
-    , unpack, length)
+    , pack, unpack, length)
 import Data.ByteString.Internal (c2w, w2c)
 import qualified Data.ByteString.Lazy as L (ByteString, fromStrict, toStrict)
 import Data.Hashable (Hashable)
@@ -57,8 +57,6 @@ A block of data in binary form.
 -}
 data Bytes
     = StrictBytes B.ByteString
-    | LazyBytes L.ByteString
-    | ListBytes [Word8]
     deriving (Show, Eq)
 
 {-|
@@ -72,13 +70,20 @@ class Binary α where
     fromBytes :: Bytes -> α
     intoBytes :: α -> Bytes
 
+{-| from "Data.ByteString" Strict -}
 instance Binary B.ByteString where
     fromBytes (StrictBytes b') = b'
     intoBytes b' = StrictBytes b'
 
+{-| "Data.ByteString.Lazy" -}
 instance Binary L.ByteString where
     fromBytes (StrictBytes b') = L.fromStrict b'
     intoBytes b' = StrictBytes (L.toStrict b')      -- expensive
+
+{-| "Data.Word" -}
+instance Binary [Word8] where
+    fromBytes (StrictBytes b') = B.unpack b'
+    intoBytes = StrictBytes . B.pack
 
 -- (), aka Unit, aka **1**, aka something with only one inhabitant
 

--- a/lib/Core/Text/Bytes.hs
+++ b/lib/Core/Text/Bytes.hs
@@ -29,13 +29,14 @@ or consuming bytes.
 module Core.Text.Bytes
     ( Bytes
     , Binary(fromBytes, intoBytes)
+    , hOutput
     , chunk
     ) where
 
 import Data.Bits (Bits (..))
 import Data.Char (intToDigit)
 import qualified Data.ByteString as B (ByteString, foldl', splitAt
-    , pack, unpack, length)
+    , pack, unpack, length, hPut)
 import Data.ByteString.Internal (c2w, w2c)
 import qualified Data.ByteString.Lazy as L (ByteString, fromStrict, toStrict)
 import Data.Hashable (Hashable)
@@ -49,6 +50,7 @@ import Data.Text.Prettyprint.Doc
     )
 import Data.Text.Prettyprint.Doc.Render.Terminal (
     color, colorDull, bold, Color(..))
+import System.IO (Handle)
 
 import Core.Text.Utilities
 
@@ -75,15 +77,40 @@ instance Binary B.ByteString where
     fromBytes (StrictBytes b') = b'
     intoBytes b' = StrictBytes b'
 
-{-| "Data.ByteString.Lazy" -}
+{-| from "Data.ByteString.Lazy" -}
 instance Binary L.ByteString where
     fromBytes (StrictBytes b') = L.fromStrict b'
     intoBytes b' = StrictBytes (L.toStrict b')      -- expensive
 
-{-| "Data.Word" -}
+{-| from "Data.Word" -}
 instance Binary [Word8] where
     fromBytes (StrictBytes b') = B.unpack b'
     intoBytes = StrictBytes . B.pack
+
+{-|
+Output the content of the 'Bytes' to the specified 'Handle'.
+
+@
+    hOutput h b
+@
+
+'Core.Program.Execute.output' provides a convenient way to write a @Bytes@
+to a file or socket handle from within the 'Core.Program.Execute.Program'
+monad.
+
+Don't use this function to write to @stdout@ if you are using any of the
+other output or logging facililities of this libarary as you will corrupt
+the ordering of output on the user's terminal. Instead do:
+
+@
+    write (intoRope b)
+@
+
+on the assumption that the bytes in question are UTF-8 (or plain ASCII)
+encoded.
+-}
+hOutput :: Handle -> Bytes -> IO ()
+hOutput handle (StrictBytes b') = B.hPut handle b'
 
 -- (), aka Unit, aka **1**, aka something with only one inhabitant
 

--- a/lib/Core/Text/Rope.hs
+++ b/lib/Core/Text/Rope.hs
@@ -81,7 +81,7 @@ module Core.Text.Rope
       {-* Interoperation and Output -}
     , Textual(fromRope, intoRope, append)
     , unsafeIntoRope
-    , hOutput
+    , hWrite
       {-* Internals -}
     , unRope
     , Width(..)
@@ -142,7 +142,7 @@ inserting it. Often the pieces are tiny. To add text to a @Rope@ use the
 'append' method as below or ('Data.Semigroup.<>') from "Data.Monoid" (like you
 would have with a @Builder@).
 
-Output to a @Handle@ can be done efficiently with 'hOutput'.
+Output to a @Handle@ can be done efficiently with 'hWrite'.
 -}
 data Rope
     = Rope (F.FingerTree Width S.ShortText)
@@ -309,7 +309,7 @@ empty @Rope@ will be returned.
 
 Several of the 'fromRope' implementations are expensive and involve a lot
 of intermiate allocation and copying. If you're ultimately writing to a
-handle prefer 'hOutput' which will write directly to the output buffer.
+handle prefer 'hWrite' which will write directly to the output buffer.
 -}
 class Textual α where
     {-|
@@ -383,7 +383,7 @@ you can use this function to convert to a piece of @Rope@.
 unsafeIntoRope :: B.ByteString -> Rope
 unsafeIntoRope = Rope . F.singleton . S.fromByteStringUnsafe
 
-{-| "Data.String" -}
+{-| from "Data.String" -}
 instance Textual [Char] where
     fromRope (Rope x) = foldr h [] x
       where
@@ -403,7 +403,7 @@ main =
     text :: 'Rope'
     text = "Hello World"
   in
-    'hOutput' 'System.IO.stdout' text
+    'hWrite' 'System.IO.stdout' text
 @
 because it's tradition.
 
@@ -418,9 +418,8 @@ If you're working in the 'Core.Program.Execute.Program' monad, then
 'Core.Program.Execute.write' provides an efficient way to write a @Rope@ to
 @stdout@.
 -}
-
-hOutput :: Handle -> Rope -> IO ()
-hOutput handle (Rope x) = B.hPutBuilder handle (foldr j mempty x)
+hWrite :: Handle -> Rope -> IO ()
+hWrite handle (Rope x) = B.hPutBuilder handle (foldr j mempty x)
   where
     j piece built = (<>) (S.toBuilder piece) built
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.4.3
+version: 0.4.4
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.4.4
+version: 0.4.5
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/tests/SimpleExperiment.hs
+++ b/tests/SimpleExperiment.hs
@@ -32,7 +32,7 @@ j = JsonObject
                 ]))
         ]
 
-b = StrictBytes (S.pack "{\"cost\": 4500}")
+b = intoBytes (S.pack "{\"cost\": 4500}")
 
 r = JsonArray [JsonBool False, JsonNull, 42]
 


### PR DESCRIPTION
Finally end the experiment with multiple constructors for different kinds of underlying sources of bytes, instead delegating conversion to a typeclass Binary the same way Rope delegates to Textual.

Improve documentation somewhat.

Rename `hOutput` in Rope to `hWrite`, matching the "write" name pattern in the Program monad and freeing up the "output" name pattern to be used in Bytes as it already was in Program.