### PR TITLE
Function to unlift from IO back to Program

### DIFF
--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -478,6 +478,110 @@ getContext = do
     context <- ask
     return context
 
+{-|
+The 'Program' monad is an instance of 'MonadIO', which makes sense; it's
+just a wrapper around doing 'IO' and you call it using 'execute' from the
+top-level @main@ action that is the entrypoint to any program.  So when you
+need to actually do some I/O or interact with other major libraries in the
+Haskell ecosystem, you need to get back to 'IO' and you use 'liftIO' to do
+it:
+
+@
+main :: 'IO' ()
+main = 'execute' $ do
+    -- now in the Program monad
+    'write' "Hello there"
+
+    'liftIO' $ do
+        -- do something in IO
+        source <- readFile "hello.c"
+        compileSourceCode source
+
+    -- back in Program monad
+    'write' \"Finished\"
+@
+
+and this is a perfectly reasonably pattern.
+
+Sometimes, however, you want to somehow get back to the 'Program' monad
+from there, and that's tricky; you can't just 'execute' a new program (and
+don't try: we've already initialized output and logging channels, signal
+handlers, your application context, etc).
+
+@
+main :: 'IO' ()
+main = 'execute' $ do
+    -- now in the Program monad
+    'write' "Hello there"
+
+    'liftIO' $ do
+        -- do something in IO
+        source <- readFile "hello.c"
+        -- log that we're starting compile      ... how???
+        result <- compileSourceCode source
+        case result of
+            Right object -> linkObjectCode object
+            Left err     -> -- debug the error  ... how???
+
+    -- back in Program monad
+    'write' \"Finished\"
+@
+
+We have a problem, because we'd like to do is use, say, 'debug' to log the
+compiler error, but we have no way to unlift back out of 'IO' to get to the
+'Program' monad.
+
+To workaround this, we offer 'withContext'. It gives you a function that
+you can use within your lifted 'IO' to run a 'Program' action.
+
+@
+    'withContext' $ \\runProgram -> do
+        action              :: IO
+        action              :: IO
+        runProgram ...      :: Program -> IO
+        action              :: IO
+@
+
+Think of this as 'liftIO' with an escape hatch.
+
+The type signature of this function is a bit involved, but this example
+shows that the lambda gives you a /function/ as its argument (we recommend
+you name it @runProgram@ for consistency) which gives you a way to run a
+subprogram, be that a single action like writing to terminal or logging, or
+a larger action in a do-notation block:
+
+@
+main :: 'IO' ()
+main = 'execute' $ do
+    -- now in the Program monad
+    'write' "Hello there"
+
+    'withContext' $ \\runProgram -> do
+        -- do something in IO
+        source <- readFile "hello.c"
+
+        runProgram $ do
+            -- now in Program monad
+            'event' \"Starting compile...\"
+            'event' \"Nah. Changed our minds\"
+            'event' \"Ok, fine, compile the thing\"
+
+        -- more IO
+        result <- compileSourceCode source
+        case result of
+            'Right' object -> linkObjectCode object
+            'Left' err     -> runProgram ('debugS' err)
+
+    -- back in Program monad
+    'write' \"Finished\"
+@
+
+Sometimes Haskell type inference can give you trouble because it tends to
+assume you mean what you say with the last statement of do-notation block.
+If you've got the type wrong you'll get an error, but in an odd place,
+probably at the top. This can be confusing. If you're having trouble with
+the types try putting @return ()@ at the end of your subprogram.
+-}
 -- I think I just discovered the same pattern as **unliftio**? Certainly
 -- the signature is similar. I'm not sure if there is any benefit to
 -- restating this as a `withRunInIO` action; we're deliberately trying to

--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -79,10 +79,10 @@ module Core.Program.Execute
       , None(..)
       , isNone
       , unProgram
-      , getContext
-      , subProgram
       , unThread
       , withContext
+      , getContext
+      , subProgram
     ) where
 
 import Prelude hiding (log)
@@ -118,7 +118,10 @@ import Core.Program.Arguments
 unProgram :: Program τ α -> ReaderT (Context τ) IO α
 unProgram (Program reader) = reader
 
-subProgram :: Context τ -> Program τ a -> IO a
+{-|
+Run a subprogram from within a lifted 'IO' block.
+-}
+subProgram :: Context τ -> Program τ α -> IO α
 subProgram context (Program reader) = do
     runReaderT reader context
 
@@ -473,6 +476,9 @@ getCommandLine = do
     context <- ask
     return (commandLineFrom context)
 
+{-|
+Get the internal @Context@ of the running @Program@.
+-}
 getContext :: Program τ (Context τ)
 getContext = do
     context <- ask
@@ -581,6 +587,18 @@ assume you mean what you say with the last statement of do-notation block.
 If you've got the type wrong you'll get an error, but in an odd place,
 probably at the top. This can be confusing. If you're having trouble with
 the types try putting @return ()@ at the end of your subprogram.
+
+This function is named 'withContext' because it is a convenience around the
+following pattern:
+
+@
+    context <- 'getContext'
+    liftIO $ do
+        ...
+        'subProgram' context $ do
+            -- now in Program monad
+        ...
+@
 -}
 -- I think I just discovered the same pattern as **unliftio**? Certainly
 -- the signature is similar. I'm not sure if there is any benefit to

--- a/lib/Core/System/Base.hs
+++ b/lib/Core/System/Base.hs
@@ -10,6 +10,7 @@ module Core.System.Base
       {-** from Control.Monad.IO.Class -}
       {-| Re-exported from "Control.Monad.IO.Class" in __base__: -}
       liftIO
+    , MonadIO
       {-** from System.IO -}
       {-| Re-exported from "System.IO" in __base__: -}
     , Handle
@@ -26,7 +27,7 @@ module Core.System.Base
     ) where
 
 import Control.Exception.Safe (Exception(..), throw, bracket, catch)
-import Control.Monad.IO.Class (liftIO)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import System.IO (Handle, stdin, stdout, stderr, hFlush)
 import System.IO.Unsafe (unsafePerformIO)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.4.5
+version: 0.4.6
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
Expose `withContext` which provides a function that can be used within an lifted IO block to return back (unlift?) to the Program monad.