### PR TITLE
Utility functions for handling parsed command-line parameters

### DIFF
--- a/lib/Core/Program/Arguments.hs
+++ b/lib/Core/Program/Arguments.hs
@@ -28,9 +28,9 @@ module Core.Program.Arguments
       , baselineOptions
       , Parameters(..)
       , ParameterValue(..)
-      , lookupArgument
-      , lookupOptionValue
       , lookupOptionFlag
+      , lookupOptionValue
+      , lookupArgument
       , invalid
         {-* Options and Arguments -}
       , LongName(..)

--- a/lib/Core/Program/Arguments.hs
+++ b/lib/Core/Program/Arguments.hs
@@ -29,6 +29,9 @@ module Core.Program.Arguments
       , Parameters(..)
       , ParameterValue(..)
       , lookupArgument
+      , lookupOptionValue
+      , lookupOptionFlag
+      , invalid
         {-* Options and Arguments -}
       , LongName(..)
       , ShortName
@@ -376,13 +379,31 @@ data Parameters
 Arguments are mandatory, so by the time your program is running a value
 has already been identified. This returns the value for that parameter.
 -}
-lookupArgument :: LongName -> Parameters -> String
+-- this is Maybe because you can inadvertently ask for an unconfigured name
+-- this could be fixed with a much stronger Config type, potentially.
+lookupArgument :: LongName -> Parameters -> Maybe String
 lookupArgument name params =
     case HashMap.lookup name (parameterValuesFrom params) of
         Nothing -> invalid
         Just argument -> case argument of
             Empty -> invalid
-            Value value -> value
+            Value value -> Just value
+
+lookupOptionValue :: LongName -> Parameters -> Maybe String
+lookupOptionValue name params =
+    case HashMap.lookup name (parameterValuesFrom params) of
+        Nothing -> Nothing
+        Just argument -> case argument of
+            Empty -> invalid    -- FIXME, no not invalid. User error
+            Value value -> Just value
+
+lookupOptionFlag :: LongName -> Parameters -> Maybe ()
+lookupOptionFlag name params =
+    case HashMap.lookup name (parameterValuesFrom params) of
+        Nothing -> Nothing
+        Just argument -> case argument of
+            _ -> Just ()        -- nom, nom
+
 
 -- Illegal internal state resulting from programmer error
 invalid :: a

--- a/lib/Core/Program/Arguments.hs
+++ b/lib/Core/Program/Arguments.hs
@@ -28,10 +28,6 @@ module Core.Program.Arguments
       , baselineOptions
       , Parameters(..)
       , ParameterValue(..)
-      , lookupOptionFlag
-      , lookupOptionValue
-      , lookupArgument
-      , invalid
         {-* Options and Arguments -}
       , LongName(..)
       , ShortName
@@ -375,48 +371,6 @@ data Parameters
         , environmentValuesFrom :: HashMap LongName ParameterValue
     } deriving (Show, Eq)
 
-{-|
-Arguments are mandatory, so by the time your program is running a value
-has already been identified. This returns the value for that parameter.
--}
--- this is Maybe because you can inadvertently ask for an unconfigured name
--- this could be fixed with a much stronger Config type, potentially.
-lookupArgument :: LongName -> Parameters -> Maybe String
-lookupArgument name params =
-    case HashMap.lookup name (parameterValuesFrom params) of
-        Nothing -> invalid
-        Just argument -> case argument of
-            Empty -> invalid
-            Value value -> Just value
-
-{-|
-Look to see if the user supplied a valued option and if so, what it's value
-was.
--}
-lookupOptionValue :: LongName -> Parameters -> Maybe String
-lookupOptionValue name params =
-    case HashMap.lookup name (parameterValuesFrom params) of
-        Nothing -> Nothing
-        Just argument -> case argument of
-            Empty -> Nothing
-            Value value -> Just value
-
-{-|
-Returns @Just True@ if the option is present, and @Nothing@ if it is not.
--}
--- The type is boolean to support a possible future extension of negated
--- arguments.
-lookupOptionFlag :: LongName -> Parameters -> Maybe Bool
-lookupOptionFlag name params =
-    case HashMap.lookup name (parameterValuesFrom params) of
-        Nothing -> Nothing
-        Just argument -> case argument of
-            _ -> Just True        -- nom, nom
-
-
--- Illegal internal state resulting from programmer error
-invalid :: a
-invalid = error "Invalid State"
 
 baselineOptions :: [Options]
 baselineOptions =

--- a/lib/Core/Program/Arguments.hs
+++ b/lib/Core/Program/Arguments.hs
@@ -389,20 +389,29 @@ lookupArgument name params =
             Empty -> invalid
             Value value -> Just value
 
+{-|
+Look to see if the user supplied a valued option and if so, what it's value
+was.
+-}
 lookupOptionValue :: LongName -> Parameters -> Maybe String
 lookupOptionValue name params =
     case HashMap.lookup name (parameterValuesFrom params) of
         Nothing -> Nothing
         Just argument -> case argument of
-            Empty -> invalid    -- FIXME, no not invalid. User error
+            Empty -> Nothing
             Value value -> Just value
 
-lookupOptionFlag :: LongName -> Parameters -> Maybe ()
+{-|
+Returns @Just True@ if the option is present, and @Nothing@ if it is not.
+-}
+-- The type is boolean to support a possible future extension of negated
+-- arguments.
+lookupOptionFlag :: LongName -> Parameters -> Maybe Bool
 lookupOptionFlag name params =
     case HashMap.lookup name (parameterValuesFrom params) of
         Nothing -> Nothing
         Just argument -> case argument of
-            _ -> Just ()        -- nom, nom
+            _ -> Just True        -- nom, nom
 
 
 -- Illegal internal state resulting from programmer error

--- a/lib/Core/Program/Arguments.hs
+++ b/lib/Core/Program/Arguments.hs
@@ -28,6 +28,7 @@ module Core.Program.Arguments
       , baselineOptions
       , Parameters(..)
       , ParameterValue(..)
+      , lookupArgument
         {-* Options and Arguments -}
       , LongName(..)
       , ShortName
@@ -370,6 +371,22 @@ data Parameters
         , parameterValuesFrom :: HashMap LongName ParameterValue
         , environmentValuesFrom :: HashMap LongName ParameterValue
     } deriving (Show, Eq)
+
+{-|
+Arguments are mandatory, so by the time your program is running a value
+has already been identified. This returns the value for that parameter.
+-}
+lookupArgument :: LongName -> Parameters -> String
+lookupArgument name params =
+    case HashMap.lookup name (parameterValuesFrom params) of
+        Nothing -> invalid
+        Just argument -> case argument of
+            Empty -> invalid
+            Value value -> value
+
+-- Illegal internal state resulting from programmer error
+invalid :: a
+invalid = error "Invalid State"
 
 baselineOptions :: [Options]
 baselineOptions =

--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -80,6 +80,7 @@ module Core.Program.Execute
       , isNone
       , unProgram
       , unThread
+      , invalid
     ) where
 
 import Prelude hiding (log)

--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -461,6 +461,36 @@ sleep seconds =
 {-|
 Retrieve the values of parameters parsed from options and arguments
 supplied by the user on the command-line.
+
+The command-line parameters are returned in a 'Data.HashMap.Strict.HashMap'
+mapping from from the option or argument name to the supplied value. With
+the somewhat traditional qualified import from the __unordered-containers__
+package:
+
+@
+import qualified "Data.HashMap.Strict" as HashMap
+@
+
+You can query this map directly:
+
+@
+    params <- 'getCommandLine'
+    let result = HashMap.'Data.HashMap.Strict.lookup' \"silence\" params
+    case result of
+        'Nothing' -> 'terminate' 1
+        'Just' quiet = case quiet of
+            'Value' _ ->  -- complain that the silence flag doesn't take a value
+            'Empty'   -> 'write' "You should be quiet now"
+@
+
+which is pattern matching to answer "was this option specified by the
+user?" or "what was the value of this [mandatory] argument?"
+
+This is available should you need to differentiate between an @Value@ and
+@Empty@ 'ParameterValue', but for many cases as a convenience you can use
+the 'lookupOptionFlag', 'lookupOptionValue', and 'lookupArgument' functions
+below, which are just wrappers around a code block like the example shown
+here.
 -}
 getCommandLine :: Program τ (Parameters)
 getCommandLine = do

--- a/lib/Core/Text/Utilities.hs
+++ b/lib/Core/Text/Utilities.hs
@@ -32,7 +32,7 @@ import Data.Text.Prettyprint.Doc (Doc, layoutPretty , reAnnotateS
     , pretty, emptyDoc
     , LayoutOptions(LayoutOptions)
     , PageWidth(AvailablePerLine))
-import Data.Text.Prettyprint.Doc.Render.Terminal (renderStrict, AnsiStyle)
+import Data.Text.Prettyprint.Doc.Render.Terminal (renderLazy, AnsiStyle)
 import Language.Haskell.TH (litE, stringL)
 import Language.Haskell.TH.Quote (QuasiQuoter(QuasiQuoter))
 
@@ -113,7 +113,7 @@ render columns (thing :: α) =
   let
     options = LayoutOptions (AvailablePerLine (columns - 1) 1.0)
   in
-    intoRope . renderStrict . reAnnotateS (colourize @α)
+    intoRope . renderLazy . reAnnotateS (colourize @α)
                 . layoutPretty options . intoDocA $ thing
 
 --

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.4.8
+version: 0.4.9
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
Add

* `lookupOptionsFlag`,
* `lookupOptionsValue`, and
* `lookupArgument`

trialling out actually _using_ the result of loading a program with a command-line Config.