### PR TITLE
Specify labels for options that take values

### DIFF
--- a/lib/Core/Program/Arguments.hs
+++ b/lib/Core/Program/Arguments.hs
@@ -120,17 +120,18 @@ of optional parameters and mandatory arguments. For example:
 main :: 'IO' ()
 main = do
     context <- 'Core.Program.Execute.configure' 'Core.Program.Execute.None' ('simple'
-        [ 'Option' "host" ('Just' \'h\') ['quote'|
+        [ 'Option' "host" ('Just' \'h\') 'Empty' ['quote'|
             Specify an alternate host to connect to when performing the
             frobnication. The default is \"localhost\".
           |]
-        , 'Option' "port" ('Just' \'p\') ['quote'|
+        , 'Option' "port" ('Just' \'p\') 'Empty' ['quote'|
             Specify an alternate port to connect to when frobnicating.
           |]
-        , 'Option' "dry-run" 'Nothing' ['quote'|
-            Perform a trial run but don't actually do anything.
+        , 'Option' "dry-run" 'Nothing' ('Value' \"TIME\") ['quote'|
+            Perform a trial run at the specified time but don't actually
+            do anything.
           |]
-        , 'Option' "quiet" ('Just' \'q\') ['quote'|
+        , 'Option' "quiet" ('Just' \'q\') 'Empty' ['quote'|
             Supress normal output.
           |]
         , 'Argument' "filename" ['quote'|
@@ -155,12 +156,15 @@ Available options:
   -h, --host     Specify an alternate host to connect to when performing the
                  frobnication. The default is \"localhost\".
   -p, --port     Specify an alternate port to connect to when frobnicating.
-      --dry-run  Perform a trial run but don't actually do anything.
+      --dry-run=TIME
+                 Perform a trial run at the specified time but don't
+                 actually do anything.
   -q, --quiet    Supress normal output.
   -v, --verbose  Turn on event tracing. By default the logging stream will go
                  to standard output on your terminal.
       --debug    Turn on debug level logging. Implies --verbose.
-      --logging  Change where log messages are sent. Valid values are
+      --logging=WHERE
+                 Change where log messages are sent. Valid values are
                  \"console\", \"file:\/path\/to\/filename.log\", and \"syslog\".
 
 Required arguments:
@@ -190,7 +194,7 @@ main :: 'IO' ()
 main = do
     context <- 'Core.Program.Execute.configure' 'mempty' ('complex'
         [ 'Global'
-            [ 'Option' "station-name" ('Just' \'s\') ['quote'|
+            [ 'Option' "station-name" 'Nothing' ('Value' \"NAME\") ['quote'|
                 Specify an alternate radio station to connect to when performing
                 actions. The default is \"BBC Radio 1\".
               |]
@@ -200,26 +204,26 @@ main = do
               |]
             ]
         , 'Command' \"play\" \"Play the music.\"
-            [ 'Option' "repeat" 'Nothing' ['quote'|
+            [ 'Option' "repeat" 'Nothing' 'Empty' ['quote'|
                 Request that they play the same song over and over and over
                 again, simulating the effect of listening to a Top 40 radio
                 station.
               |]
             ]
         , 'Command' \"rate\" \"Vote on whether you like the song or not.\"
-            [ 'Option' "academic" 'Nothing' ['quote'|
+            [ 'Option' "academic" 'Nothing' 'Empty' ['quote'|
                 The rating you wish to apply, from A+ to F. This is the
                 default, so there is no reason whatsoever to specify this.
                 But some people are obsessive, compulsive, and have time on
                 their hands.
               |]
-            , 'Option' "numeric" 'Nothing' ['quote'|
+            , 'Option' "numeric" 'Nothing' 'Empty' ['quote'|
                 Specify a score as a number from 0 to 100 instead of an
                 academic style letter grade. Note that negative values are
                 not valid scores, despite how vicerally satisfying that
                 would be for music produced in the 1970s.
               |]
-            , 'Option' "unicode" ('Just' \'c\') ['quote'|
+            , 'Option' "unicode" ('Just' \'c\') 'Empty' ['quote'|
                 Instead of a score, indicate your rating with a single
                 character.  This allows you to use emoji, so that you can
                 rate a piece \'💩\', as so many songs deserve.
@@ -274,25 +278,27 @@ Declaration of an optional switch or mandatory argument expected by a
 program.
 
 'Option' takes a long name for the option, a short single character
-abbreviation if offered for convenience, and a description for use when
-displaying usage via @--help@.
+abbreviation if offered for convenience, whether or not the option takes a
+value (and what label to show in help output) and a description for use
+when displaying usage via @--help@.
 
 'Argument' indicates a mandatory argument and takes the long name used
 to identify the parsed value from the command-line, and likewise a
 description for @--help@ output.
 
-By convention these are both /lower case/. If the identifier is two or
-more words they are joined with a hyphen. Examples:
+By convention option and argument names are both /lower case/. If the
+identifier is two or more words they are joined with a hyphen. Examples:
 
 @
-        [ 'Option' \"dry-run\" 'Nothing' "Don't actually execute commands, just simulate what would happen."
-        , 'Option' \"quiet\" ('Just' \'q'\) "Keep the noise to a minimum."
-        , 'Argument' \"username\" "The user to delete from the system."
+        [ 'Option' \"quiet\" ('Just' \'q'\) 'Empty' \"Keep the noise to a minimum.\"
+        , 'Option' \"dry-run\" 'Nothing' ('Value' \"TIME\") \"Run a simulation of what would happen at the specified time.\"
+        , 'Argument' \"username\" \"The user to delete from the system.\"
         ]
 @
 
 By convention a /description/ is one or more complete sentences each of
-which ends with a full stop.
+which ends with a full stop. For options that take values, use /upper case/
+when specifying the label to be used in help output.
 
 'Variable' declares an /environment variable/ that, if present, will be
 read by the program and stored in its runtime context. By convention these

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.4.9
+version: 0.5.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,2 @@
-resolver: lts-12.12
+resolver: lts-12.18
 allow-newer: true

--- a/tests/CheckArgumentsParsing.hs
+++ b/tests/CheckArgumentsParsing.hs
@@ -9,18 +9,18 @@ import Test.Hspec
 import Core.Program.Arguments
 
 options1 =
-    [ Option "verbose" (Just 'v') "Make the program verbose"
-    , Option "quiet" (Just 'q') "Be very very quiet, we're hunting wabbits"
-    , Option "dry-run" Nothing "Before trapping Road Runner, best to do a dry-run"
+    [ Option "verbose" (Just 'v') Empty "Make the program verbose"
+    , Option "quiet" (Just 'q') Empty "Be very very quiet, we're hunting wabbits"
+    , Option "dry-run" Nothing (Value "WHEN") "Before trapping Road Runner, best to do a dry-run"
     ]
 
 options2 =
-    [ Option "recursive" Nothing "Descend into darkness"
+    [ Option "recursive" Nothing Empty "Descend into darkness"
     , Argument "filename" "The file that you want"
     ]
 
 options3 =
-    [ Option "all" (Just 'a') "Good will to everyone"
+    [ Option "all" (Just 'a') Empty "Good will to everyone"
     ]
 
 
@@ -64,6 +64,16 @@ checkArgumentsParsing = do
             actual `shouldBe` Right expect
 
         it "recognizes required arguments" $
+          let
+            config = simple options2
+            actual = parseCommandLine config ["hello.txt"]
+            expect = Parameters Nothing
+              [ ("filename", Value "hello.txt")
+              ] []
+          in
+            actual `shouldBe` Right expect
+
+        it "handles valued parameter" $
           let
             config = simple options2
             actual = parseCommandLine config ["hello.txt"]

--- a/tests/CheckProgramMonad.hs
+++ b/tests/CheckProgramMonad.hs
@@ -13,7 +13,7 @@ import Core.System.Base
 
 options :: [Options]
 options =
-    [ Option "all" (Just 'a') "Good will to everyone"
+    [ Option "all" (Just 'a') Empty "Good will to everyone"
     ]
 
 commands :: [Commands]

--- a/tests/ComplexExperiment.hs
+++ b/tests/ComplexExperiment.hs
@@ -25,10 +25,10 @@ main :: IO ()
 main = do
     context <- configure None (complex
         [ Global
-            [ Option "logging-and-cutting" Nothing [quote|
+            [ Option "logging-and-cutting" Nothing (Value "PLACE") [quote|
                 Valid values are "console", "file:/path/to/file.log", and "syslog".
               |]
-            , Option "quiet" (Just 'q') [quote|
+            , Option "quiet" (Just 'q') Empty [quote|
                 Supress normal output.
               |]
             , Variable "GITHUB_TOKEN" "OAuth token to access GitHub."
@@ -39,12 +39,12 @@ main = do
             ]
 
         , Command "commit" "Commit your changes to the repository."
-            [ Option "message" (Just 'm') "Specify commit message (instead of using editor)."
+            [ Option "message" Nothing (Value "MESSAGE") "Specify commit message (instead of using editor)."
             ]
 
         , Command "launch" "Fire the weapons at the alien horde."
-            [ Option "all" (Just 'a') "Target all the baddies."
-            , Option "other" Nothing "Another option."
+            [ Option "all" (Just 'a') Empty "Target all the baddies."
+            , Option "other" Nothing (Value "THING") "Another option."
             , Argument "input-file" [quote|
                 The file you want to read the launch codes from.
               |]

--- a/tests/SimpleExperiment.hs
+++ b/tests/SimpleExperiment.hs
@@ -95,7 +95,7 @@ program = do
 main :: IO ()
 main = do
     context <- configure None (simple
-        [ Option "quiet" (Just 'q') [quote|
+        [ Option "quiet" (Just 'q') Empty [quote|
             Supress normal output.
           |]
         , Argument "filename" [quote|


### PR DESCRIPTION
Overload use of ParameterValue type to indicate in an Option declaration whether a parameter expects a value, and if so what label to use for it in the generated `--help` output.