### PR TITLE
Specify program version number when configuring.

### DIFF
--- a/lib/Core/Program/Arguments.hs
+++ b/lib/Core/Program/Arguments.hs
@@ -120,7 +120,7 @@ of optional parameters and mandatory arguments. For example:
 @
 main :: 'IO' ()
 main = do
-    context <- 'Core.Program.Execute.configure' 'Core.Program.Execute.None' ('simple'
+    context <- 'Core.Program.Execute.configure' \"1.0\" 'Core.Program.Execute.None' ('simple'
         [ 'Option' "host" ('Just' \'h\') 'Empty' ['quote'|
             Specify an alternate host to connect to when performing the
             frobnication. The default is \"localhost\".
@@ -193,7 +193,7 @@ program = ...
 
 main :: 'IO' ()
 main = do
-    context <- 'Core.Program.Execute.configure' 'mempty' ('complex'
+    context <- 'Core.Program.Execute.configure' ('Core.Program.Execute.fromPackage' version) 'mempty' ('complex'
         [ 'Global'
             [ 'Option' "station-name" 'Nothing' ('Value' \"NAME\") ['quote'|
                 Specify an alternate radio station to connect to when performing

--- a/lib/Core/Program/Arguments.hs
+++ b/lib/Core/Program/Arguments.hs
@@ -40,6 +40,7 @@ module Core.Program.Arguments
       , extractValidEnvironments
       , InvalidCommandLine(..)
       , buildUsage
+      , buildVersion
     ) where
 
 import Control.Exception.Safe (Exception(displayException))
@@ -407,6 +408,8 @@ data InvalidCommandLine
     | NoCommandFound        {-^ In a complex configuration, user didn't specify a command. -}
     | HelpRequest (Maybe LongName)
                             {-^ In a complex configuration, usage information was requested with @--help@, either globally or for the supplied command. -}
+    | VersionRequest
+                            {-^ Display of the program version requested with @--version@. -}
     deriving (Show, Eq)
 
 instance Exception InvalidCommandLine where
@@ -460,6 +463,9 @@ See --help for details.
 |]
         -- handled by parent module calling back into here buildUsage
         HelpRequest _ -> ""
+
+        -- handled by parent module calling back into here buildVersion
+        VersionRequest -> ""
 
 programName :: String
 programName = unsafePerformIO getProgName
@@ -526,6 +532,7 @@ parsePossibleOptions mode valids shorts args = mapM f args
     f arg = case arg of
         "--help" -> Left (HelpRequest mode)
         "-?"     -> Left (HelpRequest mode)
+        "--version" -> Left VersionRequest
         ('-':'-':name) -> considerLongOption name
         ('-':c:[]) -> considerShortOption c
         _ -> Left (InvalidOption arg)
@@ -831,4 +838,8 @@ buildUsage config mode = case config of
       in
         fillBreak 16 ("  " <> l <> " ") <+> align (reflow d) <> hardline <> acc
     h _ acc = acc
+
+buildVersion :: String -> Doc ann
+buildVersion version =
+    pretty programName <+> "version" <+> pretty version <> hardline
 

--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -81,6 +81,8 @@ module Core.Program.Execute
       , Context
       , None(..)
       , isNone
+      , Version
+      , fromPackage
       , unProgram
       , unThread
       , invalid
@@ -170,7 +172,7 @@ calls 'configure' with an appropriate default when initializing.
 -}
 execute :: Program None α -> IO ()
 execute program = do
-    context <- configure None (simple [])
+    context <- configure "" None (simple [])
     executeWith context program
 
 {-|

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.5.1
+version: 0.6.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -77,7 +77,8 @@ executables:
     ghc-options: -threaded
     source-dirs: tests
     main: SimpleExperiment.hs
-    other-modules: []
+    other-modules:
+     - Paths_unbeliever
     ghc-prof-options: -fprof-auto-top
 
   snippet:

--- a/tests/CheckProgramMonad.hs
+++ b/tests/CheckProgramMonad.hs
@@ -40,14 +40,14 @@ checkProgramMonad = do
 
     describe "Program monad" $ do
         it "execute with blank Context as expected" $ do
-            context <- configure None blank
+            context <- configure "0.1" None blank
             executeWith context $ do
                 user <- getApplicationState
                 liftIO $ do
                     user `shouldBe` None
 
         it "execute with simple Context as expected" $ do
-            context <- configure None (simple options)
+            context <- configure "0.1" None (simple options)
             executeWith context $ do
                 params <- getCommandLine
                 liftIO $ do
@@ -57,7 +57,7 @@ checkProgramMonad = do
 
         -- not strictly necessary but sets up next spec item
         it "sub-programs can be run" $ do
-            context <- configure None blank
+            context <- configure "0.1" None blank
             user <- subProgram context (getApplicationState)
             user `shouldBe` None
 
@@ -70,7 +70,7 @@ checkProgramMonad = do
                     user2 `shouldBe` user1
 
         it "thrown Exceptions can be caught" $ do
-            context <- configure None blank
+            context <- configure "0.1" None blank
             (subProgram context (throw Boom)) `shouldThrow` boom
 
             -- ok, so with that established, now try **safe-exceptions**'s

--- a/tests/ComplexExperiment.hs
+++ b/tests/ComplexExperiment.hs
@@ -23,7 +23,7 @@ program = do
 
 main :: IO ()
 main = do
-    context <- configure None (complex
+    context <- configure "42.0" None (complex
         [ Global
             [ Option "logging-and-cutting" Nothing (Value "PLACE") [quote|
                 Valid values are "console", "file:/path/to/file.log", and "syslog".

--- a/tests/SimpleExperiment.hs
+++ b/tests/SimpleExperiment.hs
@@ -14,6 +14,7 @@ import qualified Data.ByteString.Char8 as S
 import qualified Data.HashMap.Strict as HashMap
 import Data.Text.Prettyprint.Doc (layoutPretty, defaultLayoutOptions, Pretty(..))
 import Data.Text.Prettyprint.Doc.Render.Text (renderStrict)
+import Paths_unbeliever (version)
 
 import Core.Text
 import Core.Encoding
@@ -91,10 +92,9 @@ program = do
     event "Brr! It's cold"
     terminate 0
 
-
 main :: IO ()
 main = do
-    context <- configure None (simple
+    context <- configure (fromPackage version) None (simple
         [ Option "quiet" (Just 'q') Empty [quote|
             Supress normal output.
           |]


### PR DESCRIPTION
In order to support a built-in `--version` option, we need to know the program's version number. We get the author to supply that using the `configure` function at the beginning of the program by requiring version to be supplied to `configure`.

Signature change bumps major API version to 0.6.