### PR TITLE
Extract build metadata from project .cabal file

### DIFF
--- a/lib/Core/Program.hs
+++ b/lib/Core/Program.hs
@@ -22,6 +22,7 @@ and more.
 -}
         module Core.Program.Execute
       , module Core.Program.Unlift
+      , module Core.Program.Metadata
 
         {-* Command-line argument parsing -}
 {-|
@@ -38,7 +39,8 @@ Facilities for noting events through your program and doing debugging.
     ) where
 
 import Core.Program.Arguments
-import Core.Program.Logging
 import Core.Program.Execute
+import Core.Program.Logging
+import Core.Program.Metadata
 import Core.Program.Unlift
 

--- a/lib/Core/Program/Arguments.hs
+++ b/lib/Core/Program/Arguments.hs
@@ -836,7 +836,7 @@ buildUsage config mode = case config of
 buildVersion :: Version -> Doc ann
 buildVersion version =
     pretty programName
-    <+> "version"
-    <+> pretty (projectVersionFrom version)
+    <+> "v"
+    <> pretty (versionNumberFrom version)
     <> hardline
 

--- a/lib/Core/Program/Arguments.hs
+++ b/lib/Core/Program/Arguments.hs
@@ -60,6 +60,7 @@ import System.Environment (getProgName)
 import Core.System.Base
 import Core.Text.Rope
 import Core.Text.Utilities
+import Core.Program.Metadata
 
 {-|
 Single letter "short" options (omitting the "@-@" prefix, obviously).
@@ -832,7 +833,10 @@ buildUsage config mode = case config of
         fillBreak 16 ("  " <> l <> " ") <+> align (reflow d) <> hardline <> acc
     h _ acc = acc
 
-buildVersion :: String -> Doc ann
+buildVersion :: Version -> Doc ann
 buildVersion version =
-    pretty programName <+> "version" <+> pretty version <> hardline
+    pretty programName
+    <+> "version"
+    <+> pretty (projectVersionFrom version)
+    <> hardline
 

--- a/lib/Core/Program/Context.hs
+++ b/lib/Core/Program/Context.hs
@@ -255,7 +255,7 @@ getConsoleWidth = do
     up the layout width to match (one off the) actual width of console.
 -}
 handleCommandLine :: Version -> Config -> IO Parameters
-handleCommandLine (Version version) config = do
+handleCommandLine version config = do
     argv <- getArgs
     let result = parseCommandLine config argv
     case result of

--- a/lib/Core/Program/Context.hs
+++ b/lib/Core/Program/Context.hs
@@ -20,8 +20,6 @@ module Core.Program.Context
       , getContext
       , subProgram
       , getConsoleWidth
-      , Version(..)
-      , fromPackage
     ) where
 
 import Prelude hiding (log)
@@ -39,8 +37,6 @@ import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Text.Prettyprint.Doc (layoutPretty, LayoutOptions(..), PageWidth(..))
 import Data.Text.Prettyprint.Doc.Render.Text (renderIO)
-import Data.String
-import qualified Data.Version as Base (Version(..), showVersion)
 import qualified System.Console.Terminal.Size as Terminal (Window(..), size)
 import System.Environment (getArgs, getProgName, lookupEnv)
 import System.Exit (ExitCode(..), exitWith)
@@ -48,6 +44,7 @@ import System.Exit (ExitCode(..), exitWith)
 import Core.System.Base
 import Core.Text.Rope
 import Core.Program.Arguments
+import Core.Program.Metadata
 
 {-|
 Internal context for a running program. You access this via actions in the
@@ -327,37 +324,3 @@ queryVerbosityLevel params =
                 Empty   -> Right Event
                 Value _ -> Left (ExitFailure 2)
             Nothing -> Right Output
-
-{-|
-The version number of this piece of software. This is supplied to your
-program when you call 'configure'. This value is used, along with the
-proram name, if the user requests it by specifying the @--version@ option
-on the command-line. You can also call 'getVersionNumber'.
--}
-newtype Version = Version String
-
-instance IsString Version where
-    fromString = Version
-
-{-|
-If your project is named __acme__, then the Haskell compiler will create a
-module called @Paths_acme@ you can use to access various bits of useful
-build-time information, including the number from the version field
-declared in the /package.yaml/ or /acme.cabal/ file. So as an idiom, we
-support using that version number rather than having to specify it in
-multiple places:
-
-@
-import Paths_acme (version)
-
-main :: IO ()
-main = do
-    context <- 'configure' ('fromPackage' version) 'None' ('simple' ...
-@
-
-(this wraps __base__'s 'Data.Version.showVersion' and saves you from having
-to import Data.Version or use it directly)
--}
-fromPackage :: Base.Version -> Version
-fromPackage = Version . Base.showVersion
-

--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -81,8 +81,6 @@ module Core.Program.Execute
       , Context
       , None(..)
       , isNone
-      , Version
-      , fromPackage
       , unProgram
       , unThread
       , invalid

--- a/lib/Core/Program/Metadata.hs
+++ b/lib/Core/Program/Metadata.hs
@@ -41,7 +41,3 @@ projectSynopsis1 = do
     desc <- readCabalFile
     return ((LitE . StringL . synopsis . packageDescription) desc)
 
-projectSynopsis :: IO String
-projectSynopsis = do
-    desc <- runQ readCabalFile
-    return (synopsis (packageDescription desc))

--- a/lib/Core/Program/Metadata.hs
+++ b/lib/Core/Program/Metadata.hs
@@ -5,7 +5,12 @@ This uses the evil /Template Haskell/ to run code at compile time that
 parses the .cabal file for your Haskell project and extracts various
 meaningful fields.
 -}
-module Core.Program.Metadata where
+module Core.Program.Metadata
+(
+      Version(..)
+    , fromPackage
+)
+where
 
 import qualified Data.List as List
 import Data.String
@@ -16,16 +21,27 @@ import Distribution.Verbosity (normal)
 import Language.Haskell.TH (Q, runIO, Exp(..), Lit(..))
 import System.Directory (listDirectory)
 
+import Core.Text.Rope
+
 {-|
-The version number of this piece of software. This is supplied to your
+Information about the version number of this piece of software and other
+related metadata related to the project it was built from. This is supplied to your
 program when you call 'configure'. This value is used, along with the
 proram name, if the user requests it by specifying the @--version@ option
 on the command-line. You can also call 'getVersionNumber'.
+FIXME
 -}
-newtype Version = Version String
+data Version = Version {
+      projectNameFrom :: Rope
+    , projectVersionFrom :: Rope
+    , projectSynopsisFrom :: Rope
+}
+
+emptyVersion :: Version
+emptyVersion = Version mempty mempty mempty
 
 instance IsString Version where
-    fromString = Version
+    fromString x = emptyVersion { projectVersionFrom = intoRope x }
 
 {-|
 This is a splice which includes key built-time metadata, including the
@@ -50,8 +66,8 @@ provides to get a 'Version' object with the desired metadata about your
 project:
 
 @
-version :: Version
-version = $(fromPackage)
+version :: 'Version'
+version = $('fromPackage')
 
 main :: IO ()
 main = do

--- a/lib/Core/Program/Metadata.hs
+++ b/lib/Core/Program/Metadata.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE DeriveLift #-}
 
 {-|
-Dig metadata out of the .cabal file of your project.
+Dig metadata out of the description of your project.
 
 This uses the evil /Template Haskell/ to run code at compile time that
 parses the .cabal file for your Haskell project and extracts various
@@ -10,8 +10,13 @@ meaningful fields.
 -}
 module Core.Program.Metadata
 (
-      Version(..)
-    , fromPackage
+      {-* Splice -}
+      fromPackage
+      {-* Internals -}
+    , Version
+    , projectNameFrom
+    , projectSynopsisFrom
+    , versionNumberFrom
 )
 where
 
@@ -30,11 +35,11 @@ import System.Directory (listDirectory)
 
 {-|
 Information about the version number of this piece of software and other
-related metadata related to the project it was built from. This is supplied to your
-program when you call 'configure'. This value is used, along with the
-proram name, if the user requests it by specifying the @--version@ option
-on the command-line. You can also call 'getVersionNumber'.
-FIXME
+related metadata related to the project it was built from. This is supplied
+to your program when you call 'configure'. This value is used if the user
+requests it by specifying the @--version@ option on the command-line. You
+can also call various accessors like 'versionNumberFrom' to access
+individual fields.
 -}
 data Version = Version {
       projectNameFrom :: String
@@ -66,7 +71,7 @@ To use this, enable the Template Haskell language extension in your
 \{\-\# LANGUAGE TemplateHaskell \#\-\}
 @
 
-Then use the special @$( ... ) "insert splice here" syntax that extension
+Then use the special @$( ... )@ "insert splice here" syntax that extension
 provides to get a 'Version' object with the desired metadata about your
 project:
 

--- a/lib/Core/Program/Metadata.hs
+++ b/lib/Core/Program/Metadata.hs
@@ -1,0 +1,24 @@
+module Core.Program.Metadata where
+
+import Distribution.Types.GenericPackageDescription (GenericPackageDescription, packageDescription)
+import Distribution.Types.PackageDescription (synopsis)
+import Distribution.PackageDescription.Parsec (readGenericPackageDescription)
+import Distribution.Verbosity (normal)
+import Language.Haskell.TH (Q, runQ, runIO)
+
+readCabalFile :: Q GenericPackageDescription
+readCabalFile = runIO $ do
+    -- Find .cabal file
+    let file = "unbeliever.cabal"
+    
+    -- Parse .cabal file
+    desc <- readGenericPackageDescription normal file
+
+    -- pass to calling program
+    return desc
+
+
+projectSynopsis :: IO String
+projectSynopsis = do
+    desc <- runQ readCabalFile
+    return (synopsis (packageDescription desc))

--- a/lib/Core/Program/Metadata.hs
+++ b/lib/Core/Program/Metadata.hs
@@ -22,6 +22,7 @@ import Distribution.Types.PackageDescription (synopsis, package)
 import Distribution.Types.PackageId (pkgName, pkgVersion)
 import Distribution.Types.PackageName (unPackageName)
 import Distribution.PackageDescription.Parsec (readGenericPackageDescription)
+import Distribution.Pretty (prettyShow)
 import Distribution.Verbosity (normal)
 import Language.Haskell.TH (Q, runIO)
 import Language.Haskell.TH.Syntax (Lift, Exp(..))
@@ -37,15 +38,15 @@ FIXME
 -}
 data Version = Version {
       projectNameFrom :: String
-    , projectVersionFrom :: String
     , projectSynopsisFrom :: String
+    , versionNumberFrom :: String
 } deriving (Show, Lift)
 
 emptyVersion :: Version
-emptyVersion = Version "" "" ""
+emptyVersion = Version "" "" "0"
 
 instance IsString Version where
-    fromString x = emptyVersion { projectVersionFrom = x }
+    fromString x = emptyVersion { versionNumberFrom = x }
 
 {-|
 This is a splice which includes key built-time metadata, including the
@@ -89,19 +90,18 @@ fromPackage = do
     let desc = packageDescription generic
         version = Version
             { projectNameFrom = unPackageName . pkgName . package $ desc
-            , projectVersionFrom = show . pkgVersion . package $ desc
             , projectSynopsisFrom = synopsis desc
+            , versionNumberFrom = prettyShow . pkgVersion . package $ desc
             }
 
---  I would have preferred 
+--  I would have preferred
 --
 --  let e = AppE (VarE ...
 --  return e
 --
 --  but that's not happening. So more voodoo TH nonsense instead.
+
     [e|version|]
-
-
 
 
 {-

--- a/lib/Core/Program/Metadata.hs
+++ b/lib/Core/Program/Metadata.hs
@@ -1,15 +1,33 @@
+{-|
+Dig metadata out of the .cabal file of your project.
+
+This uses the evil /Template Haskell/ to run code at compile time that
+parses the .cabal file for your Haskell project and extracts various
+meaningful fields.
+-}
 module Core.Program.Metadata where
 
+import qualified Data.List as List
 import Distribution.Types.GenericPackageDescription (GenericPackageDescription, packageDescription)
 import Distribution.Types.PackageDescription (synopsis)
 import Distribution.PackageDescription.Parsec (readGenericPackageDescription)
 import Distribution.Verbosity (normal)
-import Language.Haskell.TH (Q, runQ, runIO)
+import Language.Haskell.TH (Q, runQ, runIO, Exp(..), Lit(..))
+import System.Directory (listDirectory)
+
+
+findCabalFile :: IO FilePath
+findCabalFile = do
+    files <- listDirectory "."
+    let found = List.find (List.isSuffixOf ".cabal") files
+    case found of
+        Just file -> return file
+        Nothing -> error "No .cabal file found"
 
 readCabalFile :: Q GenericPackageDescription
 readCabalFile = runIO $ do
     -- Find .cabal file
-    let file = "unbeliever.cabal"
+    file <- findCabalFile
     
     -- Parse .cabal file
     desc <- readGenericPackageDescription normal file
@@ -17,6 +35,11 @@ readCabalFile = runIO $ do
     -- pass to calling program
     return desc
 
+
+projectSynopsis1 :: Q Exp
+projectSynopsis1 = do
+    desc <- readCabalFile
+    return ((LitE . StringL . synopsis . packageDescription) desc)
 
 projectSynopsis :: IO String
 projectSynopsis = do

--- a/lib/Core/Text/Rope.hs
+++ b/lib/Core/Text/Rope.hs
@@ -102,6 +102,7 @@ import qualified Data.Text.Lazy as U (Text, fromChunks, foldrChunks
     , toStrict)
 import qualified Data.Text.Lazy.Builder as U (Builder, toLazyText
     , fromText)
+import Data.Text.Prettyprint.Doc (Doc, Pretty(..), emptyDoc)
 import qualified Data.Text.Short as S (ShortText, length, any
     , fromText, toText, fromByteString, pack, unpack
     , append, empty, toBuilder, splitAt)
@@ -160,6 +161,8 @@ instance Eq Rope where
       where
         stream x = foldMap S.unpack x
 
+instance Pretty Rope where
+    pretty (Rope x) = foldr ((<>) . pretty . S.toText) emptyDoc x 
 
 {-|
 Access the finger tree underlying the @Rope@. You'll want the following

--- a/lib/Core/Text/Rope.hs
+++ b/lib/Core/Text/Rope.hs
@@ -102,7 +102,7 @@ import qualified Data.Text.Lazy as U (Text, fromChunks, foldrChunks
     , toStrict)
 import qualified Data.Text.Lazy.Builder as U (Builder, toLazyText
     , fromText)
-import Data.Text.Prettyprint.Doc (Doc, Pretty(..), emptyDoc)
+import Data.Text.Prettyprint.Doc (Pretty(..), emptyDoc)
 import qualified Data.Text.Short as S (ShortText, length, any
     , fromText, toText, fromByteString, pack, unpack
     , append, empty, toBuilder, splitAt)

--- a/package.yaml
+++ b/package.yaml
@@ -61,11 +61,11 @@ library:
    - Core.Program.Arguments
    - Core.Program.Execute
    - Core.Program.Logging
+   - Core.Program.Metadata
    - Core.Program.Unlift
   other-modules:
    - Core.Program.Context
    - Core.Program.Signal
-   - Core.Program.Metadata
 
 executables:
   experiment:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.6.2
+version: 0.6.3
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ dependencies:
  - Cabal
  - chronologique
  - deepseq
+ - directory
  - exceptions
  - fingertree
  - hashable
@@ -64,6 +65,7 @@ library:
   other-modules:
    - Core.Program.Context
    - Core.Program.Signal
+   - Core.Program.Metadata
 
 executables:
   experiment:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.6.1
+version: 0.6.2
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -22,6 +22,7 @@ dependencies:
  - async
  - base
  - bytestring
+ - Cabal
  - chronologique
  - deepseq
  - exceptions

--- a/tests/SimpleExperiment.hs
+++ b/tests/SimpleExperiment.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
@@ -14,7 +15,6 @@ import qualified Data.ByteString.Char8 as S
 import qualified Data.HashMap.Strict as HashMap
 import Data.Text.Prettyprint.Doc (layoutPretty, defaultLayoutOptions, Pretty(..))
 import Data.Text.Prettyprint.Doc.Render.Text (renderStrict)
-import Paths_unbeliever (version)
 
 import Core.Text
 import Core.Encoding
@@ -92,9 +92,12 @@ program = do
     event "Brr! It's cold"
     terminate 0
 
+version :: Version
+version = $(fromPackage)
+
 main :: IO ()
 main = do
-    context <- configure (fromPackage version) None (simple
+    context <- configure version None (simple
         [ Option "quiet" (Just 'q') Empty [quote|
             Supress normal output.
           |]


### PR DESCRIPTION
Third or fourth attempt to find a good way to extract metadata from the _.cabal_ file of a project being built. This one uses Template Haskell (groan) but means that the **Cabal** library is confined to splces only evaluated at build time and thereby avoids a > 10 MB penalty to the size of your binary.