### PR TITLE
Guard against collapse of logging and output threads

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -94,7 +94,7 @@ Some goals:
 
   - Provide a place to implement common application functionality. Over
     time, ideas about best practices evolve. Current approaches to
-    structuring programs include an outer layer over `IO `which carries the
+    structuring programs include an outer layer over `IO` which carries the
     application's state and makes it available to inner layers which can be
     more restricted or better yet pure. This library includes an
     implementation of that pattern.

--- a/lib/Core/Data/Structures.hs
+++ b/lib/Core/Data/Structures.hs
@@ -198,14 +198,14 @@ instance Key κ => Dictionary (Map κ ν) where
     fromMap = id
     intoMap = id
 
-{-| from "Data.HashMap.Strict" -}
+{-| from "Data.HashMap.Strict" (and .Lazy) -}
 instance Key κ => Dictionary (HashMap.HashMap κ ν) where
     type K (HashMap.HashMap κ ν) = κ
     type V (HashMap.HashMap κ ν) = ν
     fromMap (Map u) = u
     intoMap u = Map u
 
-{-| from "Data.Map.Strict" -}
+{-| from "Data.Map.Strict" (and .Lazy) -}
 instance Key κ => Dictionary (OrdMap.Map κ ν) where
     type K (OrdMap.Map κ ν) = κ
     type V (OrdMap.Map κ ν) = ν

--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_HADDOCK prune #-}
 
@@ -376,7 +377,7 @@ write text = do
     liftIO $ do
         let out = outputChannelFrom context
 
-        text' <- Base.evaluate text
+        !text' <- Base.evaluate text
         atomically (writeTQueue out text')
 
 {-|
@@ -401,7 +402,7 @@ writeR thing = do
         let columns = terminalWidthFrom context
 
         let text = render columns thing
-        text' <- Base.evaluate text
+        !text' <- Base.evaluate text
         atomically (writeTQueue out text')
 
 {-|

--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -356,7 +356,8 @@ write text = do
     liftIO $ do
         let out = outputChannelFrom context
 
-        atomically (writeTQueue out text)
+        text' <- Base.evaluate text
+        atomically (writeTQueue out text')
 
 {-|
 Call 'show' on the supplied argument and write the resultant text to
@@ -380,8 +381,8 @@ writeR thing = do
         let columns = terminalWidthFrom context
 
         let text = render columns thing
-
-        atomically (writeTQueue out text)
+        text' <- Base.evaluate text
+        atomically (writeTQueue out text')
 
 {-|
 Write the supplied @Bytes@ to the given @Handle@. Note that in contrast to

--- a/lib/Core/Program/Logging.hs
+++ b/lib/Core/Program/Logging.hs
@@ -18,6 +18,7 @@ import Chrono.TimeStamp (TimeStamp(..), getCurrentTimeNanoseconds)
 import Control.Concurrent.MVar (readMVar)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TQueue (writeTQueue)
+import Control.Exception (evaluate)
 import Control.Monad (when)
 import Control.Monad.Reader.Class (MonadReader(ask))
 import Data.Fixed
@@ -161,7 +162,8 @@ debug label value = do
         level <- readMVar (verbosityLevelFrom context)
         when (isDebug level) $ do
             now <- getCurrentTimeNanoseconds
-            putMessage context (Message now Debug label (Just value))
+            value' <- evaluate value
+            putMessage context (Message now Debug label (Just value'))
 
 {-|
 Convenience for the common case of needing to inspect the value
@@ -191,6 +193,6 @@ debugR label thing = do
             -- TODO take into account 22 width already consumed by timestamp
             -- TODO move render to putMessage? putMessageR?
             let value = render columns thing
-
-            putMessage context (Message now Debug label (Just value))
+            value' <- evaluate value
+            putMessage context (Message now Debug label (Just value'))
 

--- a/lib/Core/Program/Logging.hs
+++ b/lib/Core/Program/Logging.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_HADDOCK prune #-}
 
 module Core.Program.Logging
@@ -162,7 +163,7 @@ debug label value = do
         level <- readMVar (verbosityLevelFrom context)
         when (isDebug level) $ do
             now <- getCurrentTimeNanoseconds
-            value' <- evaluate value
+            !value' <- evaluate value
             putMessage context (Message now Debug label (Just value'))
 
 {-|
@@ -193,6 +194,6 @@ debugR label thing = do
             -- TODO take into account 22 width already consumed by timestamp
             -- TODO move render to putMessage? putMessageR?
             let value = render columns thing
-            value' <- evaluate value
+            !value' <- evaluate value
             putMessage context (Message now Debug label (Just value'))
 

--- a/package.yaml
+++ b/package.yaml
@@ -86,6 +86,7 @@ executables:
     ghc-options: -threaded
     source-dirs: tests
     main: SimpleExperiment.hs
+    other-modules: []
     ghc-prof-options: -fprof-auto-top
 
   snippet:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.7.2
+version: 0.7.3
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/tests/Snippet.hs
+++ b/tests/Snippet.hs
@@ -9,11 +9,23 @@ import qualified Data.ByteString.Char8 as C
 
 import Core.Program
 import Core.Text
+import Core.System
 
 b = intoBytes (C.pack "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+
+data Boom = Boom deriving Show
+instance Exception Boom
 
 main :: IO ()
 main = execute $ do
     event "Processing..."
     debugR "b" b
+
+    let x = error "No!"
+
+    write $ case x of
+        Nothing -> "Nothing!"
+
+    sleep 0.2
+
     write "Done"


### PR DESCRIPTION
Resolve a race condition that occurred. Numerous problems:

1. Exceptions were being thrown to logging/output thread rather than at call site if a lazy value that resulted in an exception was passed in. Resolve that with `evaluate` and `!` in `write` and friends.
2. Exception thrown in logging/output handler resulted in its collapse. Resolve this by hard-terminating the program if a logging/output thread dies prematurely.
3. The code allowing time to drain the queues at shutdown was looping forever because there was no longer anything to drain the queues. Resolve this with a timeout implemented using `race_`
