### PR TITLE
Remove Cabal dependency

### DIFF
--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -68,6 +68,7 @@ module Core.Program.Execute
       , update
         {-* Useful actions -}
       , output
+      , input
         {-* Concurrency -}
       , Thread
       , fork
@@ -389,8 +390,13 @@ correctly. If you wish to write to the terminal use:
 blob you pass in is other than UTF-8 text).
 -}
 output :: Handle -> Bytes -> Program τ ()
-output h b = liftIO $ do
-        B.hPut h (fromBytes b)
+output handle contents = liftIO (hOutput handle contents)
+
+{-|
+Read the (entire) contents of the specified @Handle@.
+-}
+input :: Handle -> Program τ Bytes
+input handle = liftIO (hInput handle)
 
 {-|
 A thread for concurrent computation. Haskell uses green threads: small

--- a/lib/Core/System/Base.hs
+++ b/lib/Core/System/Base.hs
@@ -14,6 +14,8 @@ module Core.System.Base
       {-** from System.IO -}
       {-| Re-exported from "System.IO" in __base__: -}
     , Handle
+    , IOMode(..)
+    , withFile
     , stdin, stdout, stderr
     , hFlush
     , unsafePerformIO
@@ -32,6 +34,6 @@ module Core.System.Base
 import Control.Exception.Safe (Exception(..), SomeException, throw
     , bracket, catch, finally, impureThrow)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import System.IO (Handle, stdin, stdout, stderr, hFlush)
+import System.IO (Handle, IOMode(..), withFile, stdin, stdout, stderr, hFlush)
 import System.IO.Unsafe (unsafePerformIO)
 

--- a/lib/Core/Text/Bytes.hs
+++ b/lib/Core/Text/Bytes.hs
@@ -115,7 +115,7 @@ other output or logging facililities of this libarary as you will corrupt
 the ordering of output on the user's terminal. Instead do:
 
 @
-    Core.Program.Execute.write' ('intoRope' b)
+    'Core.Program.Execute.write' ('intoRope' b)
 @
 
 on the assumption that the bytes in question are UTF-8 (or plain ASCII)

--- a/lib/Core/Text/Bytes.hs
+++ b/lib/Core/Text/Bytes.hs
@@ -52,6 +52,7 @@ import Data.Text.Prettyprint.Doc.Render.Terminal (
     color, colorDull, bold, Color(..))
 import System.IO (Handle)
 
+import Core.Text.Rope
 import Core.Text.Utilities
 
 {-|
@@ -92,6 +93,10 @@ instance Binary L.ByteString where
 instance Binary [Word8] where
     fromBytes (StrictBytes b') = B.unpack b'
     intoBytes = StrictBytes . B.pack
+
+instance Binary Rope where
+    fromBytes (StrictBytes b') = intoRope b'
+    intoBytes = StrictBytes . fromRope
 
 {-|
 Output the content of the 'Bytes' to the specified 'Handle'.

--- a/lib/Core/Text/Bytes.hs
+++ b/lib/Core/Text/Bytes.hs
@@ -30,13 +30,14 @@ module Core.Text.Bytes
     ( Bytes
     , Binary(fromBytes, intoBytes)
     , hOutput
+    , hInput
     , chunk
     ) where
 
 import Data.Bits (Bits (..))
 import Data.Char (intToDigit)
 import qualified Data.ByteString as B (ByteString, foldl', splitAt
-    , pack, unpack, length, hPut)
+    , pack, unpack, length, hPut, hGetContents)
 import Data.ByteString.Internal (c2w, w2c)
 import qualified Data.ByteString.Lazy as L (ByteString, fromStrict, toStrict)
 import Data.Hashable (Hashable)
@@ -114,7 +115,7 @@ other output or logging facililities of this libarary as you will corrupt
 the ordering of output on the user's terminal. Instead do:
 
 @
-    write (intoRope b)
+    Core.Program.Execute.write' ('intoRope' b)
 @
 
 on the assumption that the bytes in question are UTF-8 (or plain ASCII)
@@ -122,6 +123,23 @@ encoded.
 -}
 hOutput :: Handle -> Bytes -> IO ()
 hOutput handle (StrictBytes b') = B.hPut handle b'
+
+{-|
+Read the (entire) contents of a handle into a Bytes object.
+
+If you want to read the entire contents of a file, you can do:
+
+@
+    contents <- 'Core.System.Base.withFile' name 'Core.System.Base.ReadMode' 'hInput'
+@
+
+At any kind of scale, Streaming I/O is almost always for better, but for
+small files you need to pick apart this is fine.
+-}
+hInput :: Handle -> IO Bytes
+hInput handle = do
+   contents <- B.hGetContents handle
+   return (StrictBytes contents)
 
 -- (), aka Unit, aka **1**, aka something with only one inhabitant
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.9.2.1
+version: 0.9.3.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -29,7 +29,6 @@ dependencies:
  - async
  - base >= 4.11 && < 5
  - bytestring
- - Cabal
  - chronologique
  - containers
  - deepseq


### PR DESCRIPTION
For some time depending directly on the **Cabal** package has been problematic. It's very heavy weight, and was causing trouble with links in Haddock due to some massive re-exports of everything in Prelude. Remove the use of the proper _.cabal_ file parser and do something simple and brute force to get the few fields we're interested in out.