### PR TITLE
Force the locale of a running Program to be UTF-8

### DIFF
--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -99,6 +99,7 @@ import Control.Monad.Reader.Class (MonadReader(ask))
 import qualified Data.ByteString as B (hPut)
 import qualified Data.ByteString.Char8 as C (singleton)
 import GHC.Conc (numCapabilities, getNumProcessors, setNumCapabilities)
+import GHC.IO.Encoding (setLocaleEncoding, utf8)
 import System.Exit (ExitCode(..))
 import qualified System.Posix.Process as Posix (exitImmediately)
 
@@ -189,6 +190,9 @@ executeWith :: Context τ -> Program τ α -> IO ()
 executeWith context program = do
     -- command line +RTS -Nn -RTS value
     when (numCapabilities == 1) (getNumProcessors >>= setNumCapabilities)
+
+    -- force UTF-8 working around bad VMs
+    setLocaleEncoding utf8
 
     let quit = exitSemaphoreFrom context
         level = verbosityLevelFrom context

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.9.3.0
+version: 0.9.3.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
Work around the problem that some VMs (ie that used by Docker-for-Mac) don't seem to carry a modern locale, resulting in crashing programs if anyone outputs a character greater than \xFF. Jeesh.

This was motivated by a user of **publsh** encountering a `commitAndReleaseBuffer: invalid argument (invalid character)` crash when having the temerity to try rendering a document that had a unicode character in it. See https://github.com/oprdyn/publish/issues/32. They're specific setup was running under Docker-for-Mac; I infer that VM doesn't have a proper Unicode locale present.

This patch fixes a Program by forcing the locale to UTF-8 when `execute` is first called.