### PR TITLE
Fix breaking behaviour

### DIFF
--- a/lib/Core/Program/Metadata.hs
+++ b/lib/Core/Program/Metadata.hs
@@ -155,6 +155,7 @@ parseCabalFile contents =
   in
     breakup contents
 
+-- this should probably be a function in Core.Text.Rope
 breakRope :: (Char -> Bool) -> Rope -> (Rope,Rope)
 breakRope predicate text =
   let

--- a/lib/Core/Text/Breaking.hs
+++ b/lib/Core/Text/Breaking.hs
@@ -1,8 +1,32 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+module Core.Text.Breaking where
+
 import qualified Data.Text.Short as S
+import Data.Foldable (foldl')
 
 import Core.Text.Rope
+
+-- for left fold
+intoPieces :: (Char -> Bool) -> [S.ShortText] -> S.ShortText -> [S.ShortText] -- maybe Rope at this point?
+intoPieces predicate [] piece =
+  let
+    pieces = intoChunks predicate piece
+  in
+    pieces
+intoPieces predicate list piece =
+  let
+    previous = last list
+    remainder = init list
+
+    (list',piece') = if S.null previous
+            then (list,piece)
+            else (remainder,previous <> piece)
+
+    pieces = intoChunks predicate piece'
+  in
+    list' ++ pieces
+
 
 intoChunks :: (Char -> Bool) -> S.ShortText -> [S.ShortText]
 intoChunks _ piece | S.null piece = []

--- a/lib/Core/Text/Breaking.hs
+++ b/lib/Core/Text/Breaking.hs
@@ -4,28 +4,28 @@ module Core.Text.Breaking where
 
 import qualified Data.Text.Short as S
 import Data.Foldable (foldl')
+import Data.List (uncons)
 
 import Core.Text.Rope
 
--- for left fold
-intoPieces :: (Char -> Bool) -> [S.ShortText] -> S.ShortText -> [S.ShortText] -- maybe Rope at this point?
-intoPieces predicate [] piece =
+{-
+Was the previous piece a match, or are we in the middle of a run of
+characters? If we were, then join the previous run to the current piece
+before processing into chunks.
+-}
+-- now for right fold
+intoPieces :: (Char -> Bool) -> S.ShortText -> [S.ShortText] -> [S.ShortText]
+intoPieces predicate piece list =
   let
-    pieces = intoChunks predicate piece
-  in
-    pieces
-intoPieces predicate list piece =
-  let
-    previous = last list
-    remainder = init list
-
-    (list',piece') = if S.null previous
+    (list',piece') = case uncons list of
+        Nothing -> ([],piece)
+        Just (previous,remainder) -> if S.null previous
             then (list,piece)
-            else (remainder,previous <> piece)
+            else (remainder,piece <> previous)
 
     pieces = intoChunks predicate piece'
   in
-    list' ++ pieces
+    pieces ++ list'
 
 
 intoChunks :: (Char -> Bool) -> S.ShortText -> [S.ShortText]

--- a/lib/Core/Text/Breaking.hs
+++ b/lib/Core/Text/Breaking.hs
@@ -40,6 +40,17 @@ breakWords = filter (not . nullRope) . breakPieces isSpace
 {-|
 Split a paragraph of text into a list of its individual lines. The
 paragraph will be broken wherever there is a @'\n'@ character.
+
+Blank lines will be preserved.
+
+Note that you'll get a blank entry at the end of the a list of newline
+/terminated/ strings, representing the (empty) text between the last
+newline and the end of the string.
+
+@
+λ> __breakLines \"Hello\\n\\nWorld\\n\"__
+[\"Hello\",\"\",\"World\",\"\"]
+@
 -}
 breakLines :: Rope -> [Rope]
 breakLines text = breakPieces isNewline text

--- a/lib/Core/Text/Breaking.hs
+++ b/lib/Core/Text/Breaking.hs
@@ -41,19 +41,26 @@ breakWords = filter (not . nullRope) . breakPieces isSpace
 Split a paragraph of text into a list of its individual lines. The
 paragraph will be broken wherever there is a @'\n'@ character.
 
-Blank lines will be preserved.
-
-Note that you'll get a blank entry at the end of the a list of newline
-/terminated/ strings, representing the (empty) text between the last
-newline and the end of the string.
+Blank lines will be preserved. Note that as a special case you do /not/ get
+a blank entry at the end of the a list of newline terminated strings.
 
 @
 λ> __breakLines \"Hello\\n\\nWorld\\n\"__
-[\"Hello\",\"\",\"World\",\"\"]
+[\"Hello\",\"\",\"World\"]
 @
 -}
 breakLines :: Rope -> [Rope]
-breakLines text = breakPieces isNewline text
+breakLines text =
+  let
+    result = breakPieces isNewline text
+    n = length result - 1
+    (fore,aft) = splitAt n result
+  in case result of
+    [] -> []
+    [p] -> [p]
+    _ -> if aft == [""]
+        then fore
+        else result
 
 isNewline :: Char -> Bool
 isNewline c = c == '\n'

--- a/lib/Core/Text/Breaking.hs
+++ b/lib/Core/Text/Breaking.hs
@@ -3,18 +3,49 @@
 
 -- This is an Internal module, hidden from Haddock
 module Core.Text.Breaking
-    (
-      breakPieces
+    ( breakWords
+    , breakLines
+    , breakPieces
     , intoPieces
     , intoChunks
     )
 where
 
+import Data.Char (isSpace)
 import Data.Foldable (foldr)
 import Data.List (uncons)
 import qualified Data.Text.Short as S (ShortText, null, break, uncons,empty)
 
 import Core.Text.Rope
+
+{-|
+Split a passage of text into a list of words. A line is broken wherever
+there is one or more whitespace characters, as defined by "Data.Char"'s
+'Data.Char.isSpace'.
+
+Examples:
+
+@
+λ> __breakWords \"This is a test\"__
+[\"This\",\"is\",\"a\",\"test\"]
+λ> __breakWords (\"St\" <> \"op and \" <> \"go left\")__
+[\"Stop\",\"and\",\"go\",\"left\"]
+λ> __breakWords emptyRope__
+[]
+@
+-}
+breakWords :: Rope -> [Rope]
+breakWords = filter (not . nullRope) . breakPieces isSpace
+
+{-|
+Split a paragraph of text into a list of its individual lines. The
+paragraph will be broken wherever there is a @'\n'@ character.
+-}
+breakLines :: Rope -> [Rope]
+breakLines text = breakPieces isNewline text
+
+isNewline :: Char -> Bool
+isNewline c = c == '\n'
 
 {-|
 Break a Rope into pieces whereever the given predicate function returns

--- a/lib/Core/Text/Breaking.hs
+++ b/lib/Core/Text/Breaking.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import qualified Data.Text.Short as S
+
+import Core.Text.Rope
+
+intoChunks :: (Char -> Bool) -> S.ShortText -> [S.ShortText]
+intoChunks _ piece | S.null piece = []
+intoChunks predicate piece =
+  let
+    (chunk,remainder') = S.break predicate piece
+    remainder = S.drop 1 remainder'
+  in
+    chunk : intoChunks predicate remainder

--- a/lib/Core/Text/Breaking.hs
+++ b/lib/Core/Text/Breaking.hs
@@ -4,16 +4,30 @@
 -- This is an Internal module, hidden from Haddock
 module Core.Text.Breaking
     (
-      intoPieces
+      breakPieces
+    , intoPieces
     , intoChunks
     )
 where
 
-import Data.Foldable (foldl')
+import Data.Foldable (foldr)
 import Data.List (uncons)
-import qualified Data.Text.Short as S
+import qualified Data.Text.Short as S (ShortText, null, drop, break)
 
 import Core.Text.Rope
+
+{-|
+Break a Rope into pieces whereever the given predicate function returns
+@True@. If found, that character will not be included on either side. Empty
+runs, however, *will* be preserved.
+-}
+breakPieces :: (Char -> Bool) -> Rope -> [Rope]
+breakPieces predicate text =
+  let
+    x = unRope text
+    result = foldr (intoPieces predicate) [] x
+  in
+    result
 
 {-
 Was the previous piece a match, or are we in the middle of a run of
@@ -35,6 +49,22 @@ intoPieces predicate piece list =
   in
     pieces ++ list'
 
+--
+-- λ> S.break isSpace "a d"
+-- ("a"," d")
+--
+-- λ> S.break isSpace " and"
+-- (""," and")
+--
+-- λ> S.break isSpace "and "
+-- ("and"," ")
+--
+-- λ> S.break isSpace ""
+-- ("","")
+--
+-- λ> S.break isSpace " "
+-- (""," ")
+--
 intoChunks :: (Char -> Bool) -> S.ShortText -> [Rope]
 intoChunks _ piece | S.null piece = []
 intoChunks predicate piece =

--- a/lib/Core/Text/Breaking.hs
+++ b/lib/Core/Text/Breaking.hs
@@ -8,7 +8,13 @@ intoChunks :: (Char -> Bool) -> S.ShortText -> [S.ShortText]
 intoChunks _ piece | S.null piece = []
 intoChunks predicate piece =
   let
-    (chunk,remainder') = S.break predicate piece
-    remainder = S.drop 1 remainder'
+    (chunk,remainder) = S.break predicate piece
+    remainder' = S.drop 1 remainder
   in
-    chunk : intoChunks predicate remainder
+    if S.null chunk
+        then if S.null remainder
+            then []
+            else S.empty : intoChunks predicate remainder'
+        else if S.null remainder
+            then chunk : []
+            else chunk : S.empty : intoChunks predicate remainder'

--- a/lib/Core/Text/Rope.hs
+++ b/lib/Core/Text/Rope.hs
@@ -84,6 +84,7 @@ module Core.Text.Rope
     , hWrite
       {-* Internals -}
     , unRope
+    , nullRope
     , unsafeIntoRope
     , Width(..)
     ) where
@@ -95,7 +96,8 @@ import qualified Data.ByteString.Builder as B (toLazyByteString
 import qualified Data.ByteString.Lazy as L (ByteString, toStrict
     , foldrChunks)
 import qualified Data.FingerTree as F (FingerTree, Measured(..), empty
-    , singleton, (><), (<|), (|>), search, SearchResult(..), null)
+    , singleton, (><), (<|), (|>), search, SearchResult(..), null
+    , viewl, ViewL(..))
 import Data.Foldable (foldr, foldr', foldMap, toList, any)
 import Data.Hashable (Hashable, hashWithSalt)
 import Data.String (IsString(..))
@@ -105,7 +107,7 @@ import qualified Data.Text.Lazy as U (Text, fromChunks, foldrChunks
 import qualified Data.Text.Lazy.Builder as U (Builder, toLazyText
     , fromText)
 import Data.Text.Prettyprint.Doc (Pretty(..), emptyDoc)
-import qualified Data.Text.Short as S (ShortText, length, any
+import qualified Data.Text.Short as S (ShortText, length, any, null
     , fromText, toText, fromByteString, pack, unpack
     , append, empty, toBuilder, splitAt)
 import qualified Data.Text.Short.Unsafe as S (fromByteStringUnsafe)
@@ -235,6 +237,11 @@ widthRope :: Rope -> Int
 widthRope = foldr' f 0 . unRope
   where
     f piece count = S.length piece + count
+
+nullRope :: Rope -> Bool
+nullRope (Rope x) = case F.viewl x of
+    F.EmptyL        -> True
+    (F.:<) piece _  -> S.null piece
 
 {-|
 Break the text into two pieces at the specified offset.

--- a/lib/Core/Text/Utilities.hs
+++ b/lib/Core/Text/Utilities.hs
@@ -25,13 +25,11 @@ module Core.Text.Utilities (
     , quote
 ) where
 
-import Data.Char (isSpace)
-import qualified Data.FingerTree as F ((<|), ViewL(..), viewl, singleton)
+import qualified Data.FingerTree as F ((<|), ViewL(..), viewl)
 import qualified Data.List as List (foldl', dropWhileEnd)
 import Data.Monoid ((<>))
 import qualified Data.Text as T
-import qualified Data.Text.Short as S (ShortText, uncons, toText, empty
-    , null, breakEnd, append, dropEnd)
+import qualified Data.Text.Short as S (ShortText, uncons, toText)
 import Data.Text.Prettyprint.Doc (Doc, layoutPretty , reAnnotateS
     , pretty, emptyDoc
     , LayoutOptions(LayoutOptions)
@@ -41,6 +39,7 @@ import Language.Haskell.TH (litE, stringL)
 import Language.Haskell.TH.Quote (QuasiQuoter(QuasiQuoter))
 
 import Core.Text.Rope
+import Core.Text.Breaking
 
 -- change AnsiStyle to a custom token type, perhaps Ansi, which
 -- has the escape codes already converted to Rope.
@@ -141,112 +140,6 @@ indefinite text =
             Just (c,_)  -> if c `elem` ['A','E','I','O','U','a','e','i','o','u']
                 then intoRope ("an " F.<| x)
                 else intoRope ("a " F.<| x)
-
-{-|
-Split a passage of text into a list of words. A line is broken wherever
-there is one or more whitespace characters, as defined by "Data.Char"'s
-'Data.Char.isSpace'.
-
-Examples:
-
-@
-λ> __breakWords \"This is a test\"__
-[\"This\",\"is\",\"a\",\"test\"]
-λ> __breakWords (\"St\" <> \"op and \" <> \"go left\")__
-[\"Stop\",\"and\",\"go\",\"left\"]
-λ> __breakWords emptyRope__
-[]
-@
--}
-breakWords :: Rope -> [Rope]
-breakWords = filter (not . nullRope) . breakPieces isSpace
-
-{-|
-Split a paragraph of text into a list of its individual lines. The
-paragraph will be broken wherever there is a @'\n'@ character.
--}
-breakLines :: Rope -> [Rope]
-breakLines text = breakPieces isNewline text
-
-isNewline :: Char -> Bool
-isNewline c = c == '\n'
-
-{-|
-Break a Rope into pieces whereever the given predicate function returns
-@True@. If found, that character will not be included on either side. Empty
-runs, however, *will* be preserved.
--}
-breakPieces :: (Char -> Bool) -> Rope -> [Rope]
-breakPieces predicate text =
-  let
-    (final,list) = foldr (finder predicate) (S.empty,[]) (unRope text)
-    l = intoRope (F.singleton final)
-  in
-    if S.null final
-        then list
-        else l:list
-
-finder
-    :: (Char -> Bool)
-    -> S.ShortText
-    -> (S.ShortText,[Rope])
-    -> (S.ShortText,[Rope])
-finder predicate piece (accum,list) =
-  let
-    done = S.null piece
-
-    -- λ> S.breakEnd isSpace "a d"
-    -- ("a ","d")
-    --
-    -- λ> S.breakEnd isSpace " and"
-    -- (" ","and")
-    --
-    -- λ> S.breakEnd isSpace "and "
-    -- ("and ","")
-    --
-    -- λ> S.breakEnd isSpace ""
-    -- ("","")
-    --
-    -- λ> S.breakEnd isSpace " "
-    -- (" ","")
-
-    (remainder,fragment) = S.breakEnd predicate piece
-
-    -- Are we in the middle of a word? We are if the carry forward is
-    -- non-zero length.
-    --
-    -- Did we find a word in the current piece? If so, then if we are in
-    -- the middle of accumulating a word, we add the new piece to it.
-
-    found  = not (S.null fragment)
-    middle = not (S.null accum)
-
-    accum' = if found
-                then if middle
-                    then S.append fragment accum
-                    else fragment
-                else accum
-
-    -- Did we find a space? We did if remainder is non-zero length.
-    -- Finding a space means flushing out the accumulator (though only if
-    -- there's actually something there). We have to drop that whitespace
-    -- before iterating.
-
-    space = not (S.null remainder)
-    empty = S.null accum'
-    word = intoRope accum'
-
-    list' = if empty
-                then list
-                else word:list
-
-    remainder' = S.dropEnd 1 remainder
-  in
-    if done
-        then (accum',list)
-        else if space
-            then finder predicate remainder' (S.empty,list')
-            else finder predicate remainder (accum',list)
 
 {-|
 Often the input text represents a paragraph, but does not have any internal

--- a/lib/Core/Text/Utilities.hs
+++ b/lib/Core/Text/Utilities.hs
@@ -195,7 +195,7 @@ finder predicate piece (accum,list) =
     done = S.null piece
 
     -- λ> S.breakEnd isSpace "a d"
-    -- ("a","d")
+    -- ("a ","d")
     --
     -- λ> S.breakEnd isSpace " and"
     -- (" ","and")

--- a/lib/Core/Text/Utilities.hs
+++ b/lib/Core/Text/Utilities.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_HADDOCK prune #-}
 
 {-|
 Useful tools for working with 'Rope's. Support for pretty printing,
@@ -23,6 +24,10 @@ module Core.Text.Utilities (
     , underline
       {-* Multi-line strings -}
     , quote
+
+    -- for testing
+    , intoPieces
+    , intoChunks
 ) where
 
 import qualified Data.FingerTree as F ((<|), ViewL(..), viewl)

--- a/lib/Core/Text/Utilities.hs
+++ b/lib/Core/Text/Utilities.hs
@@ -159,7 +159,7 @@ Examples:
 @
 -}
 breakWords :: Rope -> [Rope]
-breakWords text = breakPieces isSpace text
+breakWords = filter (not . nullRope) . breakPieces isSpace
 
 {-|
 Split a paragraph of text into a list of its individual lines. The
@@ -173,7 +173,8 @@ isNewline c = c == '\n'
 
 {-|
 Break a Rope into pieces whereever the given predicate function returns
-@True@. If found, that character will not be included on either side.
+@True@. If found, that character will not be included on either side. Empty
+runs, however, *will* be preserved.
 -}
 breakPieces :: (Char -> Bool) -> Rope -> [Rope]
 breakPieces predicate text =

--- a/package.yaml
+++ b/package.yaml
@@ -73,7 +73,7 @@ library:
    - Core.System.Base
    - Core.System.External
   other-modules:
-   - Core.Program.Breaking
+   - Core.Text.Breaking
    - Core.Program.Context
    - Core.Program.Signal
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.9.3.0
+version: 0.9.3.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/package.yaml
+++ b/package.yaml
@@ -73,6 +73,7 @@ library:
    - Core.System.Base
    - Core.System.External
   other-modules:
+   - Core.Program.Breaking
    - Core.Program.Context
    - Core.Program.Signal
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.9.3.1
+version: 0.9.3.2
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -167,11 +167,12 @@ World
             breakLines "" `shouldBe` []
             breakLines "Hello" `shouldBe` ["Hello"]
             breakLines "Hello\nWorld" `shouldBe` ["Hello","World"]
-            breakLines "Hello\n" `shouldBe` ["Hello",""]
+            breakLines "Hello\n" `shouldBe` ["Hello"]
             breakLines "\nHello" `shouldBe` ["","Hello"]
-            breakLines "\nHello\n" `shouldBe` ["","Hello",""]
-            breakLines "Hello\nWorld\n" `shouldBe` ["Hello","World",""]
-            breakLines "Hello\n\nWorld\n" `shouldBe` ["Hello","","World",""]
+            breakLines "\nHello\n" `shouldBe` ["","Hello"]
+            breakLines "Hello\nWorld\n" `shouldBe` ["Hello","World"]
+            breakLines "Hello\n\nWorld\n" `shouldBe` ["Hello","","World"]
+            breakLines "Hello\n\nWorld\n\n" `shouldBe` ["Hello","","World",""]
 
         it "single piece containing multiple lines splits correctly" $
           let
@@ -187,7 +188,6 @@ System, beeeeep
                 , "of the Emergency"
                 , "Broadcast"
                 , "System, beeeeep"
-                , ""
                 ]
 
         it "preserves blank lines" $
@@ -202,7 +202,6 @@ Third line.
                 [ "First line."
                 , ""
                 , "Third line."
-                , ""
                 ]
 
     describe "Formatting paragraphs" $ do

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -4,6 +4,7 @@
 
 module CheckRopeBehaviour where
 
+import Data.Char (isSpace)
 import qualified Data.FingerTree as F
 import qualified Data.List as List
 import qualified Data.Text as T
@@ -14,6 +15,7 @@ import Test.Hspec
 
 import Core.Text.Rope
 import Core.Text.Utilities
+import Core.Text.Breaking
 
 hydrogen = "H₂" :: Rope
 sulfate = "SO₄" :: Rope
@@ -111,6 +113,19 @@ World
             |] `shouldBe` ("Hello\nWorld\n" :: Rope)
 
     describe "Splitting into words" $ do
+        it "breaks short text into chunks" $ do
+            intoChunks isSpace "Hello" `shouldBe` ["Hello"]
+            intoChunks isSpace "Hello World" `shouldBe` ["Hello","","World"]
+            intoChunks isSpace "Hello " `shouldBe` ["Hello",""]
+            intoChunks isSpace " Hello" `shouldBe` ["","Hello"]
+            intoChunks isSpace " Hello " `shouldBe` ["","Hello",""]
+
+        it "breaks consecutive short texts into chunks" $ do
+            intoPieces isSpace ["This","","is",""] "a test" `shouldBe`
+                ["This","","is","","a","","test"]
+            intoPieces isSpace ["This","","i"] "s a test" `shouldBe`
+                ["This","","is","","a","","test"]
+
         it "single piece containing multiple words splits correctly" $
           let
             text = "This is a test"

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -114,6 +114,7 @@ World
 
     describe "Splitting into words" $ do
         it "breaks short text into chunks" $ do
+            intoChunks isSpace "" `shouldBe` []
             intoChunks isSpace "Hello" `shouldBe` ["Hello"]
             intoChunks isSpace "Hello World" `shouldBe` ["Hello","","World"]
             intoChunks isSpace "Hello " `shouldBe` ["Hello",""]
@@ -121,10 +122,13 @@ World
             intoChunks isSpace " Hello " `shouldBe` ["","Hello",""]
 
         it "breaks consecutive short texts into chunks" $ do
-            intoPieces isSpace ["This","","is",""] "a test" `shouldBe`
-                ["This","","is","","a","","test"]
-            intoPieces isSpace ["This","","i"] "s a test" `shouldBe`
-                ["This","","is","","a","","test"]
+            intoPieces isSpace "Hello" [] `shouldBe` ["Hello"]
+            intoPieces isSpace "" [] `shouldBe` []
+            intoPieces isSpace "" ["World"] `shouldBe` ["World"]
+            intoPieces isSpace "This is" ["","a","","test."] `shouldBe`
+                ["This","","is","","a","","test."]
+            intoPieces isSpace "This i" ["s","","a","","test."] `shouldBe`
+                ["This","","is","","a","","test."]
 
         it "single piece containing multiple words splits correctly" $
           let

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -116,19 +116,22 @@ World
         it "breaks short text into chunks" $ do
             intoChunks isSpace "" `shouldBe` []
             intoChunks isSpace "Hello" `shouldBe` ["Hello"]
-            intoChunks isSpace "Hello World" `shouldBe` ["Hello","","World"]
+            intoChunks isSpace "Hello World" `shouldBe` ["Hello","World"]
             intoChunks isSpace "Hello " `shouldBe` ["Hello",""]
             intoChunks isSpace " Hello" `shouldBe` ["","Hello"]
             intoChunks isSpace " Hello " `shouldBe` ["","Hello",""]
 
         it "breaks consecutive short texts into chunks" $ do
-            intoPieces isSpace "Hello" [] `shouldBe` ["Hello"]
-            intoPieces isSpace "" [] `shouldBe` []
-            intoPieces isSpace "" ["World"] `shouldBe` ["World"]
-            intoPieces isSpace "This is" ["","a","","test."] `shouldBe`
-                ["This","","is","","a","","test."]
-            intoPieces isSpace "This i" ["s","","a","","test."] `shouldBe`
-                ["This","","is","","a","","test."]
+            intoPieces isSpace "Hello" (Nothing,[]) `shouldBe`
+                (Just "Hello",[])
+            intoPieces isSpace "" (Nothing,[]) `shouldBe`
+                (Nothing,[])
+            intoPieces isSpace "" (Nothing,["World"]) `shouldBe`
+                (Nothing,["World"])
+            intoPieces isSpace "This is" (Nothing,["","a","","test."]) `shouldBe`
+                (Just "This",["is","","a","","test."])
+            intoPieces isSpace "This i" (Just "s",["","a","","test."]) `shouldBe`
+                (Just "This",["is","","a","","test."])
 
         it "single piece containing multiple words splits correctly" $
           let

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -164,6 +164,16 @@ World
             breakWords text `shouldBe` ["stop"]
 
     describe "Splitting into lines" $ do
+        it "preconditions are met" $ do
+            breakLines "" `shouldBe` []
+            breakLines "Hello" `shouldBe` ["Hello"]
+            breakLines "Hello\nWorld" `shouldBe` ["Hello","World"]
+            breakLines "Hello\n" `shouldBe` ["Hello",""]
+            breakLines "\nHello" `shouldBe` ["","Hello"]
+            breakLines "\nHello\n" `shouldBe` ["","Hello",""]
+            breakLines "Hello\nWorld\n" `shouldBe` ["Hello","World",""]
+            breakLines "Hello\n\nWorld\n" `shouldBe` ["Hello","","World",""]
+
         it "single piece containing multiple lines splits correctly" $
           let
             para = [quote|
@@ -178,6 +188,7 @@ System, beeeeep
                 , "of the Emergency"
                 , "Broadcast"
                 , "System, beeeeep"
+                , ""
                 ]
 
         it "preserves blank lines" $
@@ -192,6 +203,7 @@ Third line.
                 [ "First line."
                 , ""
                 , "Third line."
+                , ""
                 ]
 
     describe "Formatting paragraphs" $ do

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -135,7 +135,7 @@ World
           in do
             breakWords text `shouldBe` ["stop","and","goop"]
 
-        it "empty and whitespace-only corner cases handled correctly " $
+        it "empty and whitespace-only corner cases handled correctly" $
           let
             text = "  " <> "" <> "stop" <> "" <> "  "
           in do
@@ -156,6 +156,20 @@ System, beeeeep
                 , "of the Emergency"
                 , "Broadcast"
                 , "System, beeeeep"
+                ]
+
+        it "preserves blank lines" $
+          let
+            para = [quote|
+First line.
+
+Third line.
+|]
+          in do
+            breakLines para `shouldBe`
+                [ "First line."
+                , ""
+                , "Third line."
                 ]
 
     describe "Formatting paragraphs" $ do

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -15,7 +15,6 @@ import Test.Hspec
 
 import Core.Text.Rope
 import Core.Text.Utilities
-import Core.Text.Breaking
 
 hydrogen = "H₂" :: Rope
 sulfate = "SO₄" :: Rope


### PR DESCRIPTION
Breaking behaviour was wrong for both `breakWords` and `breakLines`. Resolve this in new underlying `intoChunks` and `intoPieces` functions.