### PR TITLE
Re-export pretty prining and combinators for convenience

### DIFF
--- a/core-program/lib/Core/System.hs
+++ b/core-program/lib/Core/System.hs
@@ -33,8 +33,19 @@ which are maintained either by ourselves or people we are in regular
 contact with.
 -}
       , module Core.System.External
+
+        {-* Pretty Printing -}
+{-|
+When using the Render typeclass from "Core.Text.Utilities" you are
+presented with the @Doc a@ type for accumulating a \"document\" to be
+pretty printed. There are a large family of combinators used when doing
+this. For convenience they are exposed here.
+-}
+      , module Core.System.Pretty
+
     ) where
 
 import Core.System.Base
 import Core.System.External
+import Core.System.Pretty
 

--- a/core-program/lib/Core/System/Pretty.hs
+++ b/core-program/lib/Core/System/Pretty.hs
@@ -1,0 +1,51 @@
+{-# OPTIONS_HADDOCK not-home #-}
+
+--
+-- | Re-exports of combinators for use when building 'Render' instances.
+--
+module Core.System.Pretty
+    ( {-* Pretty Printing -}
+      {-** from Data.Text.Prettyprint.Doc -}
+      {-| Re-exported from "Data.Text.Prettyprint.Doc" in __prettyprinter__
+      and "Data.Text.Prettyprint.Doc.Render.Terminal" in
+      __prettyprinter-ansi-terminal__: -}
+      Doc
+    , Pretty(pretty)
+    , dquote
+    , comma
+    , punctuate
+    , lbracket
+    , rbracket
+    , (<+>)
+    , indent
+    , lbrace
+    , rbrace
+    , lparen
+    , rparen
+    , emptyDoc
+    , sep
+    , hsep
+    , vsep
+    , fillSep
+    , flatAlt
+    , hcat
+    , vcat
+    , annotate
+    , unAnnotate
+    , line
+    , line'
+    , softline
+    , softline'
+    , hardline
+    , group
+    , nest
+    , concatWith
+    , color
+    , colorDull
+    , Color(..)
+    , AnsiStyle
+    , bold
+    ) where
+
+import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc.Render.Terminal

--- a/core-program/lib/Core/System/Pretty.hs
+++ b/core-program/lib/Core/System/Pretty.hs
@@ -17,7 +17,6 @@ module Core.System.Pretty
     , lbracket
     , rbracket
     , (<+>)
-    , indent
     , lbrace
     , rbrace
     , lparen
@@ -38,6 +37,8 @@ module Core.System.Pretty
     , softline'
     , hardline
     , group
+    , hang
+    , indent
     , nest
     , concatWith
     , color

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.2.2.5
+version: 0.2.3.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -62,6 +62,7 @@ library:
    - Core.System
    - Core.System.Base
    - Core.System.External
+   - Core.System.Pretty
   other-modules:
    - Core.Program.Context
    - Core.Program.Signal

--- a/core-text/lib/Core/Text/Utilities.hs
+++ b/core-text/lib/Core/Text/Utilities.hs
@@ -108,7 +108,7 @@ instance Render Char where
 
 instance (Render a) => Render [a] where
     type Token [a] = Token a
-    colourize = const mempty
+    colourize = colourize @a
     intoDocA = mconcat . fmap intoDocA
 
 instance Render T.Text where

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -1,5 +1,5 @@
 name: core-text
-version: 0.2.2.4
+version: 0.2.2.5
 synopsis: A rope type based on a finger tree over UTF-8 fragments
 description: |
   A rope data type for text, built as a finger tree over UTF-8 text

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 resolver: lts-14.16
 packages:
- - core-data
- - core-text
- - core-program
+ - ./core-data
+ - ./core-text
+ - ./core-program
  - .


### PR DESCRIPTION
Having to import the combinators used commonly from **prettyprinter** if you're trying to build a Render instance gets a bit tedious especially if you are explicitly listing the functions you are importing.