### PR TITLE
Fix Hashable instance for Rope

### DIFF
--- a/core-text/lib/Core/Text/Rope.hs
+++ b/core-text/lib/Core/Text/Rope.hs
@@ -319,7 +319,10 @@ insertRope i (Rope new) text =
 --
 -- FingerTree Width (Hashed S.ShortText)
 --
--- at the cost of endless unwrapping.
+-- at the cost of endless unwrapping. Another alternative would be to cache
+-- hash values in the monoid, changing Width from being a wrapper of Int to
+-- a record type with width, hash, and perhaps newlines within the
+-- corresponding tree.
 --
 instance Hashable Rope where
     hashWithSalt salt (Rope x) = foldl' f salt x

--- a/core-text/lib/Core/Text/Rope.hs
+++ b/core-text/lib/Core/Text/Rope.hs
@@ -99,7 +99,7 @@ import qualified Data.ByteString.Lazy as L (ByteString, toStrict
 import qualified Data.FingerTree as F (FingerTree, Measured(..), empty
     , singleton, (><), (<|), (|>), search, SearchResult(..), null
     , viewl, ViewL(..))
-import Data.Foldable (foldr, foldr', foldMap, toList, any)
+import Data.Foldable (foldr, foldr', foldl', foldMap, toList, any)
 import Data.Hashable (Hashable, hashWithSalt)
 import Data.String (IsString(..))
 import qualified Data.Text as T (Text)
@@ -322,10 +322,10 @@ insertRope i (Rope new) text =
 -- at the cost of endless unwrapping.
 --
 instance Hashable Rope where
-    hashWithSalt salt (Rope x) = foldr f salt x
+    hashWithSalt salt (Rope x) = foldl' f salt x
       where
-        f :: S.ShortText -> Int -> Int
-        f piece num = hashWithSalt num piece
+        f :: Int -> S.ShortText  -> Int
+        f num piece = hashWithSalt num piece
 
 {-|
 Machinery to interpret a type as containing valid Unicode that can be

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -1,5 +1,5 @@
 name: core-text
-version: 0.2.2.5
+version: 0.2.2.6
 synopsis: A rope type based on a finger tree over UTF-8 fragments
 description: |
   A rope data type for text, built as a finger tree over UTF-8 text

--- a/package.yaml
+++ b/package.yaml
@@ -60,6 +60,7 @@ tests:
     dependencies:
      - bytestring
      - fingertree
+     - hashable
      - hspec
      - safe-exceptions
      - text

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -6,6 +6,7 @@ module CheckRopeBehaviour where
 
 import Data.Char (isSpace)
 import qualified Data.FingerTree as F
+import Data.Hashable (hash)
 import qualified Data.List as List
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -44,6 +45,9 @@ checkRopeBehaviour = do
              ("O" :: Rope) == ("O" :: Rope) `shouldBe` True
              ("H₂" :: Rope) == ("H₂" :: Rope) `shouldBe` True
              ("H₂" :: Rope) /= ("SO₄" :: Rope)  `shouldBe` True
+
+        it "Hashable instance behaves" $ do
+             hash ("Hello" :: Rope) `shouldBe` hash (singletonRope 'H' <> intoRope ("ello" :: String))
 
         -- depended on Textual instance for String being fixed and
         -- the Eq instance being customized to ignore tree structure


### PR DESCRIPTION
By changing to `foldl` we are able to leverage the underlying Hashable instance of the ShortByteString backing the ShortText which are the underlying units in the FingerTree backing Rope.