### PR TITLE
Utility function to calculate lines and columns

### DIFF
--- a/core-program/lib/Core/System/Pretty.hs
+++ b/core-program/lib/Core/System/Pretty.hs
@@ -12,8 +12,10 @@ module Core.System.Pretty
       Doc
     , Pretty(pretty)
     , dquote
+    , squote
     , comma
     , punctuate
+    , enclose
     , lbracket
     , rbracket
     , (<+>)

--- a/core-text/lib/Core/Text/Breaking.hs
+++ b/core-text/lib/Core/Text/Breaking.hs
@@ -8,6 +8,7 @@ module Core.Text.Breaking
     , breakPieces
     , intoPieces
     , intoChunks
+    , isNewline
     )
 where
 
@@ -62,6 +63,10 @@ breakLines text =
         then fore
         else result
 
+{-|
+Predicate testing whether a character is a newline. After
+'Data.Char.isSpace' et al in "Data.Char".
+-}
 isNewline :: Char -> Bool
 isNewline c = c == '\n'
 {-# INLINEABLE isNewline #-}

--- a/core-text/lib/Core/Text/Breaking.hs
+++ b/core-text/lib/Core/Text/Breaking.hs
@@ -64,6 +64,7 @@ breakLines text =
 
 isNewline :: Char -> Bool
 isNewline c = c == '\n'
+{-# INLINEABLE isNewline #-}
 
 {-|
 Break a Rope into pieces whereever the given predicate function returns

--- a/core-text/lib/Core/Text/Parsing.hs
+++ b/core-text/lib/Core/Text/Parsing.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_HADDOCK hide #-}
+
+-- This is an Internal module, hidden from Haddock
+module Core.Text.Parsing
+    ( calculatePositionEnd
+    )
+where
+
+import Data.Foldable (foldl)
+import qualified Data.Text.Short as S (ShortText, foldl)
+
+import Core.Text.Rope
+
+{-|
+Calculate the line number and column number of a Rope (interpreting it as
+if is a block of text in a file). By the convention observed by all leading
+brands of text editor, lines and columns are @1@ origin, so an empty Rope
+is position @(1,1)@.
+-}
+-- Of course, if Rope itself cached position information in the FingerTree
+-- monoid this would be trivial.
+
+calculatePositionEnd :: Rope -> (Int,Int)
+calculatePositionEnd text =
+  let
+    x = unRope text
+    (l,c) = foldl calculateChunk (1,1) x
+  in
+    (l,c)
+
+calculateChunk :: (Int,Int) -> S.ShortText -> (Int,Int)
+calculateChunk loc piece =
+    S.foldl f loc piece
+  where
+    f :: (Int,Int) -> Char -> (Int,Int)
+    f (l,c) ch = if ch == '\n'
+        then (l+1,1)
+        else (l,c+1)

--- a/core-text/lib/Core/Text/Parsing.hs
+++ b/core-text/lib/Core/Text/Parsing.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_HADDOCK hide #-}
 
 -- This is an Internal module, hidden from Haddock
@@ -34,6 +35,6 @@ calculateChunk loc piece =
     S.foldl f loc piece
   where
     f :: (Int,Int) -> Char -> (Int,Int)
-    f (l,c) ch = if ch == '\n'
+    f !(!l,!c) ch = if ch == '\n'
         then (l+1,1)
         else (l,c+1)

--- a/core-text/lib/Core/Text/Parsing.hs
+++ b/core-text/lib/Core/Text/Parsing.hs
@@ -21,7 +21,6 @@ is position @(1,1)@.
 -}
 -- Of course, if Rope itself cached position information in the FingerTree
 -- monoid this would be trivial.
-
 calculatePositionEnd :: Rope -> (Int,Int)
 calculatePositionEnd text =
   let

--- a/core-text/lib/Core/Text/Parsing.hs
+++ b/core-text/lib/Core/Text/Parsing.hs
@@ -8,8 +8,8 @@ module Core.Text.Parsing
     )
 where
 
-import Data.Foldable (foldl)
-import qualified Data.Text.Short as S (ShortText, foldl)
+import Data.Foldable (foldl')
+import qualified Data.Text.Short as S (ShortText, foldl')
 
 import Core.Text.Rope
 
@@ -26,13 +26,13 @@ calculatePositionEnd :: Rope -> (Int,Int)
 calculatePositionEnd text =
   let
     x = unRope text
-    (l,c) = foldl calculateChunk (1,1) x
+    (l,c) = foldl' calculateChunk (1,1) x
   in
     (l,c)
 
 calculateChunk :: (Int,Int) -> S.ShortText -> (Int,Int)
 calculateChunk loc piece =
-    S.foldl f loc piece
+    S.foldl' f loc piece
   where
     f :: (Int,Int) -> Char -> (Int,Int)
     f !(!l,!c) ch = if ch == '\n'

--- a/core-text/lib/Core/Text/Rope.hs
+++ b/core-text/lib/Core/Text/Rope.hs
@@ -78,7 +78,7 @@ module Core.Text.Rope
     , emptyRope
     , singletonRope
     , replicateRope
-    , replicateRope'
+    , replicateChar
     , widthRope
     , splitRope
     , insertRope
@@ -271,8 +271,8 @@ Rather than making a huge FingerTree full of single characters, this
 function will allocate a single ShortText comprised of the repeated input
 character.
 -}
-replicateRope' :: Int -> Char -> Rope
-replicateRope' count = Rope . F.singleton . S.replicate count . S.singleton
+replicateChar :: Int -> Char -> Rope
+replicateChar count = Rope . F.singleton . S.replicate count . S.singleton
 
 {-|
 Get the length of this text, in characters.

--- a/core-text/lib/Core/Text/Utilities.hs
+++ b/core-text/lib/Core/Text/Utilities.hs
@@ -23,6 +23,7 @@ module Core.Text.Utilities (
     , breakLines
     , breakPieces
     , wrap
+    , calculatePositionEnd
     , underline
     , leftPadWith
     , rightPadWith
@@ -62,6 +63,7 @@ import Language.Haskell.TH.Quote (QuasiQuoter(QuasiQuoter))
 
 import Core.Text.Bytes
 import Core.Text.Breaking
+import Core.Text.Parsing
 import Core.Text.Rope
 
 -- change AnsiStyle to a custom token type, perhaps Ansi, which

--- a/core-text/lib/Core/Text/Utilities.hs
+++ b/core-text/lib/Core/Text/Utilities.hs
@@ -22,6 +22,7 @@ module Core.Text.Utilities (
     , breakWords
     , breakLines
     , breakPieces
+    , isNewline
     , wrap
     , calculatePositionEnd
     , underline

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -1,5 +1,5 @@
 name: core-text
-version: 0.2.2.6
+version: 0.2.3.0
 synopsis: A rope type based on a finger tree over UTF-8 fragments
 description: |
   A rope data type for text, built as a finger tree over UTF-8 text
@@ -22,7 +22,7 @@ license: BSD3
 license-file: LICENSE
 author: Andrew Cowie <andrew@operationaldynamics.com>
 maintainer: Andrew Cowie <andrew@operationaldynamics.com>
-copyright: © 2018-2019 Operational Dynamics Consulting Pty Ltd, and Others
+copyright: © 2018-2020 Operational Dynamics Consulting Pty Ltd, and Others
 tested-with: GHC == 8.6.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
@@ -49,3 +49,4 @@ library:
    - Core.Text.Utilities
   other-modules:
    - Core.Text.Breaking
+   - Core.Text.Parsing

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -1,5 +1,5 @@
 name: core-text
-version: 0.2.3.0
+version: 0.2.3.1
 synopsis: A rope type based on a finger tree over UTF-8 fragments
 description: |
   A rope data type for text, built as a finger tree over UTF-8 text

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -1,5 +1,5 @@
 name: core-text
-version: 0.2.3.1
+version: 0.2.3.2
 synopsis: A rope type based on a finger tree over UTF-8 fragments
 description: |
   A rope data type for text, built as a finger tree over UTF-8 text

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.10.0.3
+version: 0.10.0.4
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -37,7 +37,7 @@ license: BSD3
 license-file: LICENSE
 author: Andrew Cowie <andrew@operationaldynamics.com>
 maintainer: Andrew Cowie <andrew@operationaldynamics.com>
-copyright: © 2018-2019 Operational Dynamics Consulting Pty Ltd, and Others
+copyright: © 2018-2020 Operational Dynamics Consulting Pty Ltd, and Others
 tested-with: GHC == 8.6.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs

--- a/package.yaml
+++ b/package.yaml
@@ -45,9 +45,9 @@ github: oprdyn/unbeliever
 
 dependencies:
  - base >= 4.11 && < 5
- - core-text >= 0.2.2.4
+ - core-text >= 0.2.3.0
  - core-data >= 0.2.1.4
- - core-program >= 0.2.2.5
+ - core-program >= 0.2.3.0
 
 library:
   source-dirs: tests

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.19
+resolver: lts-14.20
 packages:
  - ./core-data
  - ./core-text

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -71,8 +71,8 @@ checkRopeBehaviour = do
             length (unRope (replicateRope 3 "hello")) `shouldBe` 3
             replicateRope 3 "" `shouldBe` emptyRope
             replicateRope 0 "hello" `shouldBe` emptyRope
-            replicateRope' 3 'x' `shouldBe` ("xxx" :: Rope)
-            replicateRope' 0 'x' `shouldBe` ("" :: Rope)
+            replicateChar 3 'x' `shouldBe` ("xxx" :: Rope)
+            replicateChar 0 'x' `shouldBe` ("" :: Rope)
 
         it "exports to ByteString" $
           let

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -111,6 +111,12 @@ checkRopeBehaviour = do
             insertRope 0 "one" "twothree" `shouldBe` "onetwothree"
             insertRope 6 "three" "onetwo" `shouldBe` "onetwothree"
 
+        it "finds characters correctly" $ do
+            findIndexRope (== '3') compound `shouldBe` (Just 0)
+            findIndexRope (== '4') compound `shouldBe` (Just 8)
+            findIndexRope (== '!') compound `shouldBe` Nothing
+            findIndexRope (== 'e') compound `shouldBe` (Just 2)
+
     describe "QuasiQuoted string literals" $ do
         it "string literal is IsString" $ do
             [quote|Hello|] `shouldBe` ("Hello" :: String)

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -66,6 +66,14 @@ checkRopeBehaviour = do
         it "concatonates two Ropes correctly (Textual)" $ do
              appendRope ("SO₄" :: Rope) ("H₂" :: Rope) `shouldBe` ("H₂SO₄" :: Rope)
 
+        it "replicates itself" $ do
+            replicateRope 3 "hello" `shouldBe` ("hellohellohello" :: Rope)
+            length (unRope (replicateRope 3 "hello")) `shouldBe` 3
+            replicateRope 3 "" `shouldBe` emptyRope
+            replicateRope 0 "hello" `shouldBe` emptyRope
+            replicateRope' 3 'x' `shouldBe` ("xxx" :: Rope)
+            replicateRope' 0 'x' `shouldBe` ("" :: Rope)
+
         it "exports to ByteString" $
           let
             expected = T.encodeUtf8 (T.pack "H₂SO₄")

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -2,7 +2,11 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
-module CheckRopeBehaviour where
+module CheckRopeBehaviour
+    ( checkRopeBehaviour
+    , main
+    )
+where
 
 import Data.Char (isSpace)
 import qualified Data.FingerTree as F
@@ -16,6 +20,11 @@ import Test.Hspec
 
 import Core.Text.Rope
 import Core.Text.Utilities
+import Core.System (finally)
+
+main :: IO ()
+main = do
+    finally (hspec checkRopeBehaviour) (putStrLn ".")
 
 hydrogen = "H₂" :: Rope
 sulfate = "SO₄" :: Rope
@@ -222,3 +231,11 @@ a test
 Hello this is a test
 of the Emergency
 Broadcast System|]
+
+    describe "Lines and columns" $ do
+        it "calculate position of a given block" $ do
+            calculatePositionEnd "" `shouldBe` (1,1)
+            calculatePositionEnd "Hello" `shouldBe` (1,6)
+            calculatePositionEnd "Hello\nWorld" `shouldBe` (2,6)
+            calculatePositionEnd "\nWorld" `shouldBe` (2,6)
+            calculatePositionEnd "\n" `shouldBe` (2,1)

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -3,7 +3,7 @@
 import Test.Hspec
 
 import Core.System
-import CheckRopeBehaviour
+import CheckRopeBehaviour (checkRopeBehaviour)
 import CheckBytesBehaviour
 import CheckContainerBehaviour
 import CheckJsonWrapper


### PR DESCRIPTION
When doing parsing (and reporting error messages resulting from parse failure) we need to be able to indicate the position within the file (ie Rope representing the input).