### PR TITLE
Resolve --version not working on complex command-lines

### DIFF
--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.2.5.0
+version: 0.2.5.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
Fix handling the `Complex` case of Config so that "global" options are handed before probing for the presence of an obligatory command name. This allows the logic already in place checking for `--version`, `--help`, etc to be used before bombing out complaining no command mode was specified.

Resolves #38 